### PR TITLE
Fleshing out parseArgs to support withValue and Multiples options

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,10 @@ const parseArgs = (
         //If withValue option is specified, take 2nd part after '=' as value, else set value as undefined
         const val = options.withValue && options.withValue.includes(argParts[0]) ? argParts[1] : undefined
         //Append value to previous arg values array for case of multiples option, else add to empty array
-        result.values[argParts[0]] = [...(options.multiples && options.multiples.includes(argParts[0]) && result.values[argParts[0]] ? result.values[argParts[0]] : []), val]
+        result.values[argParts[0]] = [].concat(
+          options.multiples && options.multiples.includes(argParts[0]) && result.values[argParts[0]] || [],
+          val,
+        )
       } else if (pos + 1 < argv.length && !argv[pos+1].startsWith('-')) {
         //withValue option should also support setting values when '=' isn't used
         //ie. both --foo=b and --foo b should work

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const parseArgs = (
   if (typeof options !== 'object' || options === null) {
     throw new Error('Whoops!')
   }
-  if(options.withValue && !Array.isArray(options.withValue)) {
+  if(options.withValue !== undefined && !Array.isArray(options.withValue)) {
     throw new Error('Whoops! options.withValue should be an array.')
   }
 

--- a/index.js
+++ b/index.js
@@ -38,23 +38,26 @@ const parseArgs = (
       arg = arg.replace(/^-+/, '')
 
       if (arg.includes('=')) {
+        //withValue equals(=) case
         const argParts = arg.split('=')
 
         result.args[argParts[0]] = true
-        //If withValue option isn't specified, set value as undefined
+        //If withValue option is specified, take 2nd part after '=' as value, else set value as undefined
         const val = options.withValue && options.withValue.includes(argParts[0]) ? argParts[1] : undefined
         //Append value to previous arg values array for case of multiples option, else add to empty array
         result.values[argParts[0]] = [...(options.multiples && options.multiples.includes(argParts[0]) && result.values[argParts[0]] ? result.values[argParts[0]] : []), val]
-      } else if (pos + 1 < argv.length) {
+      } else if (pos + 1 < argv.length && !argv[pos+1].startsWith('-')) {
         //withValue option should also support setting values when '=' isn't used
-        //ie. both --foo=bar and --foo bar should work
+        //ie. both --foo=b and --foo b should work
 
         result.args[arg] = true
-        //If withValue option isn't specified, set value as undefined
+        //If withValue option is specified, take next position arguement as value and then increment pos so that we don't re-evaluate that arg, else set value as undefined
+        //ie. --foo b --bar c, after setting b as the value for foo, evaluate --bar next and skip 'b'
         const val = options.withValue && options.withValue.includes(arg) ? argv[++pos] : undefined
         //Append value to previous arg values array for case of multiples option, else add to empty array
         result.values[arg] = [...(options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : []), val]
       } else {
+        //cases when an arg is specified without a value, example '--foo --bar' <- 'foo' and 'bar' args should be set to true and have value as undefined
         result.args[arg] = true
         //Append undefined to previous arg values array for case of multiples option, else add to empty array
         result.values[arg] = [...(options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : []), undefined]

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const parseArgs = (
   if (typeof options !== 'object' || options === null) {
     throw new Error('Whoops!')
   }
-  if(options.withValue !== undefined && !Array.isArray(options.withValue)) {
+  if (options.withValue !== undefined && !Array.isArray(options.withValue)) {
     throw new Error('Whoops! options.withValue should be an array.')
   }
 

--- a/index.js
+++ b/index.js
@@ -58,12 +58,17 @@ const parseArgs = (
         //ie. --foo b --bar c, after setting b as the value for foo, evaluate --bar next and skip 'b'
         const val = options.withValue && options.withValue.includes(arg) ? argv[++pos] : undefined
         //Append value to previous arg values array for case of multiples option, else add to empty array
-        result.values[arg] = [...(options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : []), val]
+        result.values[arg] = [].concat(
+          options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : [],
+          val)
       } else {
         //cases when an arg is specified without a value, example '--foo --bar' <- 'foo' and 'bar' args should be set to true and have value as undefined
         result.args[arg] = true
         //Append undefined to previous arg values array for case of multiples option, else add to empty array
-        result.values[arg] = [...(options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : []), undefined]
+        result.values[arg] = [].concat(
+          options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : [],
+          undefined
+        )
       }
 
     } else {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ const parseArgs = (
   if (typeof options !== 'object' || options === null) {
     throw new Error('Whoops!')
   }
+  if(options.withValue && !Array.isArray(options.withValue)) {
+    throw new Error('Whoops! options.withValue should be an array.')
+  }
 
   let result = {
     args: {},
@@ -23,7 +26,6 @@ const parseArgs = (
       // and is returned verbatim
       if (arg === '--') {
         result.positionals.push(...argv.slice(++pos))
-
         return result
       }
       // look for shortcodes: -fXzy
@@ -39,14 +41,28 @@ const parseArgs = (
         const argParts = arg.split('=')
 
         result.args[argParts[0]] = true
-        if (options.withValue) {
-          result.values[argParts[0]] = argParts[1]
-        }
-      }
-      else {
-        result.args[arg] = true
+        //If withValue option isn't specified, set value as undefined
+        const val = options.withValue && options.withValue.includes(argParts[0]) ? argParts[1] : undefined
+        //Append value to previous arg values array for case of multiples option, else add to empty array
+        result.values[argParts[0]] = [...(options.multiples && options.multiples.includes(argParts[0]) && result.values[argParts[0]] ? result.values[argParts[0]] : []), val]
+      } else if (pos + 1 < argv.length) {
+        //withValue option should also support setting values when '=' isn't used
+        //ie. both --foo=bar and --foo bar should work
 
+        result.args[arg] = true
+        //If withValue option isn't specified, set value as undefined
+        const val = options.withValue && options.withValue.includes(arg) ? argv[++pos] : undefined
+        //Append value to previous arg values array for case of multiples option, else add to empty array
+        result.values[arg] = [...(options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : []), val]
+      } else {
+        result.args[arg] = true
+        //Append undefined to previous arg values array for case of multiples option, else add to empty array
+        result.values[arg] = [...(options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : []), undefined]
       }
+
+    } else {
+      //Arguements without a dash prefix are considered "positional"
+      result.positionals.push(arg)
     }
 
     pos++

--- a/index.js
+++ b/index.js
@@ -7,9 +7,6 @@ const parseArgs = (
   if (typeof options !== 'object' || options === null) {
     throw new Error('Whoops!')
   }
-  if(options.withValue && !Array.isArray(options.withValue)) {
-    throw new Error('Whoops! options.withValue should be an array.')
-  }
 
   let result = {
     args: {},
@@ -26,6 +23,7 @@ const parseArgs = (
       // and is returned verbatim
       if (arg === '--') {
         result.positionals.push(...argv.slice(++pos))
+
         return result
       }
       // look for shortcodes: -fXzy
@@ -41,28 +39,14 @@ const parseArgs = (
         const argParts = arg.split('=')
 
         result.args[argParts[0]] = true
-        //If withValue option isn't specified, set value as undefined
-        const val = options.withValue && options.withValue.includes(argParts[0]) ? argParts[1] : undefined
-        //Append value to previous arg values array for case of multiples option, else add to empty array
-        result.values[argParts[0]] = [...(options.multiples && options.multiples.includes(argParts[0]) && result.values[argParts[0]] ? result.values[argParts[0]] : []), val]
-      } else if (pos + 1 < argv.length) {
-        //withValue option should also support setting values when '=' isn't used
-        //ie. both --foo=bar and --foo bar should work
-
-        result.args[arg] = true
-        //If withValue option isn't specified, set value as undefined
-        const val = options.withValue && options.withValue.includes(arg) ? argv[++pos] : undefined
-        //Append value to previous arg values array for case of multiples option, else add to empty array
-        result.values[arg] = [...(options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : []), val]
-      } else {
-        result.args[arg] = true
-        //Append undefined to previous arg values array for case of multiples option, else add to empty array
-        result.values[arg] = [...(options.multiples && options.multiples.includes(arg) && result.values[arg] ? result.values[arg] : []), undefined]
+        if (options.withValue) {
+          result.values[argParts[0]] = argParts[1]
+        }
       }
+      else {
+        result.args[arg] = true
 
-    } else {
-      //Arguements without a dash prefix are considered "positional"
-      result.positionals.push(arg)
+      }
     }
 
     pos++

--- a/test/index.js
+++ b/test/index.js
@@ -3,8 +3,6 @@
 const test = require('tape')
 const {parseArgs} = require('../index.js')
 
-//Test results are as we expect
-
 test('Everything after a bare `--` is considered a positional argument', function (t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals']
   const expected = { args: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] }
@@ -17,7 +15,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 
 test('args are true', function (t) {
   const passedArgs = ['--foo', '--bar']
-  const expected = { args: { foo: true, bar: true}, values: {foo: [undefined], bar: [undefined]}, positionals: [] }
+  const expected = { args: { foo: true, bar: true}, values: {}, positionals: [] }
   const args = parseArgs(passedArgs)
 
   t.deepEqual(args, expected, 'args are true')
@@ -25,20 +23,10 @@ test('args are true', function (t) {
   t.end()
 })
 
-test('arg is true and positional is identified', function (t) {
-  const passedArgs = ['--foo=a', '--foo', 'b']
-  const expected = { args: { foo: true}, values: { foo: [undefined]}, positionals: ['b'] }
-  const args = parseArgs(passedArgs)
-
-  t.deepEqual(args, expected, 'arg is true and positional is identified')
-
-  t.end()
-})
-
 test('args equals are passed "withValue"', function (t) {
   const passedArgs = ['--so=wat']
-  const passedOptions = { withValue: ['so'] }
-  const expected = { args: { so: true}, values: { so: ["wat"]}, positionals: [] }
+  const passedOptions = { withValue: true }
+  const expected = { args: { so: true}, values: { so: "wat"}, positionals: [] }
   const args = parseArgs(passedArgs, passedOptions)
 
   t.deepEqual(args, expected, 'arg value is passed')
@@ -46,45 +34,3 @@ test('args equals are passed "withValue"', function (t) {
   t.end()
 })
 
-test('same arg is passed twice "withValue" and last value is recorded', function (t) {
-  const passedArgs = ['--foo=a', '--foo', 'b']
-  const passedOptions = { withValue: ['foo'] }
-  const expected = { args: { foo: true}, values: { foo: ['b']}, positionals: [] }
-  const args = parseArgs(passedArgs, passedOptions)
-
-  t.deepEqual(args, expected, 'last arg value is passed')
-
-  t.end()
-})
-
-test('args are passed "withValue" and "multiples"', function (t) {
-  const passedArgs = ['--foo=a', '--foo', 'b']
-  const passedOptions = { withValue: ['foo'], multiples: ['foo'] }
-  const expected = { args: { foo: true}, values: { foo: ['a', 'b']}, positionals: [] }
-  const args = parseArgs(passedArgs, passedOptions)
-
-  t.deepEqual(args, expected, 'both arg values are passed')
-
-  t.end()
-})
-
-
-//Test bad inputs
-
-test('boolean passed to "withValue" option', function (t) {
-  const passedArgs = ['--so=wat']
-  const passedOptions = { withValue: true }
-
-  t.throws(function() { parseArgs(passedArgs, passedOptions) });
-
-  t.end()
-})
-
-test('string passed to "withValue" option', function (t) {
-  const passedArgs = ['--so=wat']
-  const passedOptions = { withValue: 'so' }
-
-  t.throws(function() { parseArgs(passedArgs, passedOptions) });
-
-  t.end()
-})

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,8 @@
 const test = require('tape')
 const {parseArgs} = require('../index.js')
 
+//Test results are as we expect
+
 test('Everything after a bare `--` is considered a positional argument', function (t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals']
   const expected = { args: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] }
@@ -15,7 +17,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 
 test('args are true', function (t) {
   const passedArgs = ['--foo', '--bar']
-  const expected = { args: { foo: true, bar: true}, values: {}, positionals: [] }
+  const expected = { args: { foo: true, bar: true}, values: {foo: [undefined], bar: [undefined]}, positionals: [] }
   const args = parseArgs(passedArgs)
 
   t.deepEqual(args, expected, 'args are true')
@@ -23,10 +25,20 @@ test('args are true', function (t) {
   t.end()
 })
 
+test('arg is true and positional is identified', function (t) {
+  const passedArgs = ['--foo=a', '--foo', 'b']
+  const expected = { args: { foo: true}, values: { foo: [undefined]}, positionals: ['b'] }
+  const args = parseArgs(passedArgs)
+
+  t.deepEqual(args, expected, 'arg is true and positional is identified')
+
+  t.end()
+})
+
 test('args equals are passed "withValue"', function (t) {
   const passedArgs = ['--so=wat']
-  const passedOptions = { withValue: true }
-  const expected = { args: { so: true}, values: { so: "wat"}, positionals: [] }
+  const passedOptions = { withValue: ['so'] }
+  const expected = { args: { so: true}, values: { so: ["wat"]}, positionals: [] }
   const args = parseArgs(passedArgs, passedOptions)
 
   t.deepEqual(args, expected, 'arg value is passed')
@@ -34,3 +46,45 @@ test('args equals are passed "withValue"', function (t) {
   t.end()
 })
 
+test('same arg is passed twice "withValue" and last value is recorded', function (t) {
+  const passedArgs = ['--foo=a', '--foo', 'b']
+  const passedOptions = { withValue: ['foo'] }
+  const expected = { args: { foo: true}, values: { foo: ['b']}, positionals: [] }
+  const args = parseArgs(passedArgs, passedOptions)
+
+  t.deepEqual(args, expected, 'last arg value is passed')
+
+  t.end()
+})
+
+test('args are passed "withValue" and "multiples"', function (t) {
+  const passedArgs = ['--foo=a', '--foo', 'b']
+  const passedOptions = { withValue: ['foo'], multiples: ['foo'] }
+  const expected = { args: { foo: true}, values: { foo: ['a', 'b']}, positionals: [] }
+  const args = parseArgs(passedArgs, passedOptions)
+
+  t.deepEqual(args, expected, 'both arg values are passed')
+
+  t.end()
+})
+
+
+//Test bad inputs
+
+test('boolean passed to "withValue" option', function (t) {
+  const passedArgs = ['--so=wat']
+  const passedOptions = { withValue: true }
+
+  t.throws(function() { parseArgs(passedArgs, passedOptions) });
+
+  t.end()
+})
+
+test('string passed to "withValue" option', function (t) {
+  const passedArgs = ['--so=wat']
+  const passedOptions = { withValue: 'so' }
+
+  t.throws(function() { parseArgs(passedArgs, passedOptions) });
+
+  t.end()
+})


### PR DESCRIPTION
Added support for multiples option and withValue option case mentioned here https://github.com/nodejs/node/pull/35015
```
**The Requirement of = for Options Expecting a Value**
For example, one may argue that --foo=bar should be the only way to use the value bar 
for the option foo; but users of CLI apps built on Node.js expect --foo bar to work just as well. 
```
Let me know if anyone thinks I should change lines 48, 58, 63 into some helper function or make it less concise and split the logic over several lines.
Thanks for the review & consideration.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
