### PR TITLE
feat: expand scenarios covered by default arguments for environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,29 @@
 'use strict';
 
+function defaultArgv() {
+  // In node REPL, user CLI args follow executable
+  const execArgv = process.execArgv;
+  if (execArgv.includes('-e') || execArgv.includes('--eval')) {
+    return process.argv.slice(1);
+  }
+
+  // In bundled Electron app, user CLI args follow executable:
+  // 1) process.versions.electron is either set by electron, or undefined
+  //    see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
+  // 2) process.defaultApp is either set by electron in an electron
+  //    unbundled app, or undefined
+  //    see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
+  if (process.versions && process.versions.electron && !process.defaultApp) {
+    return process.argv.slice(1);
+  }
+
+  // Normally first two arguments are executable and script,
+  // then CLI arguments
+  return process.argv.slice(2);
+}
+
 const parseArgs = (
-  argv = process.argv.slice(require.main ? 2 : 1),
+  argv = defaultArgv(),
   options = {}
 ) => {
   if (typeof options !== 'object' || options === null) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@
 function defaultArgv() {
   // When evaluating script arg, user CLI args follow executable
   const execArgv = process.execArgv;
-  if (execArgv.includes('-e') || execArgv.includes('--eval')) {
+  if (execArgv.includes('-e') || execArgv.includes('--eval') ||
+      execArgv.includes('-p') || execArgv.includes('--print')) {
     return process.argv.slice(1);
   }
 

--- a/index.js
+++ b/index.js
@@ -1,30 +1,37 @@
 'use strict';
 
-function defaultArgv() {
-  // When evaluating script arg, user CLI args follow executable
+function getMainArgs() {
+  // This function is a placeholder for proposed process.mainArgs.
+  // Work out where to slice process.argv for user supplied arguments.
+
+  // Electron is an interested example, with work-arounds implemented in
+  // Commander and Yargs. Hopefully Electron would support process.mainArgs
+  // itself and render this work-around moot.
+  //
+  // In a bundled Electron app, the user CLI args directly
+  // follow executable. (No special processing required for unbundled.)
+  // 1) process.versions.electron is either set by electron, or undefined
+  //    see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
+  // 2) process.defaultApp is undefined in a bundled Electron app, and set
+  //    in an unbundled Electron app
+  //    see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
+  if (process.versions && process.versions.electron && !process.defaultApp) {
+    return process.argv.slice(1);
+  }
+
+  // Check node options for scenarios where user CLI args follow executable.
   const execArgv = process.execArgv;
   if (execArgv.includes('-e') || execArgv.includes('--eval') ||
       execArgv.includes('-p') || execArgv.includes('--print')) {
     return process.argv.slice(1);
   }
 
-  // In bundled Electron app, user CLI args follow executable:
-  // 1) process.versions.electron is either set by electron, or undefined
-  //    see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
-  // 2) process.defaultApp is either set by electron in an electron
-  //    unbundled app, or undefined
-  //    see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
-  if (process.versions && process.versions.electron && !process.defaultApp) {
-    return process.argv.slice(1);
-  }
-
-  // Normally first two arguments are executable and script,
-  // then CLI arguments
+  // Normally first two arguments are executable and script, then CLI arguments
   return process.argv.slice(2);
 }
 
 const parseArgs = (
-  argv = defaultArgv(),
+  argv = getMainArgs(),
   options = {}
 ) => {
   if (typeof options !== 'object' || options === null) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function getMainArgs() {
 
   // Electron is an interested example, with work-arounds implemented in
   // Commander and Yargs. Hopefully Electron would support process.mainArgs
-  // itself and render th  is work-around moot.
+  // itself and render this work-around moot.
   //
   // In a bundled Electron app, the user CLI args directly
   // follow executable. (No special processing required for unbundled.)

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function getMainArgs() {
   // 2) process.defaultApp is undefined in a bundled Electron app, and set
   //    in an unbundled Electron app
   //    see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
+  // (Not included in tests.)
   if (process.versions && process.versions.electron && !process.defaultApp) {
     return process.argv.slice(1);
   }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function defaultArgv() {
-  // In node REPL, user CLI args follow executable
+  // When evaluating script arg, user CLI args follow executable
   const execArgv = process.execArgv;
   if (execArgv.includes('-e') || execArgv.includes('--eval')) {
     return process.argv.slice(1);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function getMainArgs() {
 
   // Electron is an interested example, with work-arounds implemented in
   // Commander and Yargs. Hopefully Electron would support process.mainArgs
-  // itself and render this work-around moot.
+  // itself and render th  is work-around moot.
   //
   // In a bundled Electron app, the user CLI args directly
   // follow executable. (No special processing required for unbundled.)
@@ -15,7 +15,8 @@ function getMainArgs() {
   // 2) process.defaultApp is undefined in a bundled Electron app, and set
   //    in an unbundled Electron app
   //    see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
-  // (Not included in tests.)
+  // (Not included in tests as hopefully temporary example.)
+  /* c8 ignore next 3 */
   if (process.versions && process.versions.electron && !process.defaultApp) {
     return process.argv.slice(1);
   }

--- a/test/index.js
+++ b/test/index.js
@@ -68,6 +68,73 @@ test('args are passed "withValue" and "multiples"', function (t) {
   t.end()
 })
 
+test('correct default args when use node -p', function(t) {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = ['-p', '0'];
+  const args = parseArgs();
+
+  const expected = { args: { foo: true },
+                     values: { foo: [undefined] },
+                     positionals: [] };
+  t.deepEqual(args, expected, 'args are true');
+
+  t.end();
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
+test('correct default args when use node --print', function(t) {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = ['--print', '0'];
+  const args = parseArgs();
+
+  const expected = { args: { foo: true },
+                     values: { foo: [undefined] },
+                     positionals: [] };
+  t.deepEqual(args, expected, 'args are true');
+
+  t.end();
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
+test('correct default args when use node -e', function(t) {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = ['-e', '0'];
+  const args = parseArgs();
+
+  const expected = { args: { foo: true },
+                     values: { foo: [undefined] },
+                     positionals: [] };
+  t.deepEqual(args, expected, 'args are true');
+
+  t.end();
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
+test('correct default args when use node --eval', function(t) {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = ['--eval', '0'];
+  const args = parseArgs();
+
+  const expected = { args: { foo: true },
+                     values: { foo: [undefined] },
+                     positionals: [] };
+  t.deepEqual(args, expected, 'args are true');
+
+  t.end();
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
 
 //Test bad inputs
 

--- a/test/index.js
+++ b/test/index.js
@@ -136,6 +136,23 @@ test('correct default args when use node --eval', function(t) {
   process.execArgv = holdExecArgv;
 });
 
+test('correct default args when normal arguments', function(t) {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, 'script.js', '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = [];
+  const args = parseArgs();
+
+  const expected = { args: { foo: true },
+                     values: { foo: [undefined] },
+                     positionals: [] };
+  t.deepEqual(args, expected, 'args are true');
+
+  t.end();
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
 //Test bad inputs
 
 test('boolean passed to "withValue" option', function (t) {


### PR DESCRIPTION
## Problem

We are proposing to determine appropriate default arguments for `node --eval`, Electron, and ES6.

Using `require.main` to determine `--eval` (or REPL) gives false positive for ES6 main program.

Related: #5 #18

## Solution

Implement a placeholder for `process.mainArgs` that covers the scenarios that have been raised.

- detect `node --eval` directly by checking options passed to node (`-e`, `--eval`)
- detect `node --print` directly by checking options passed to node (`-p`, `--print`)
- no need to detect REPL because no user arguments from CLI?
- test for bundled Electron app (using same approach as Yargs and Commander)
- fallback to usual `process.argv.slice(2)`

Related PRs for Electron argument processing:
- https://github.com/tj/commander.js/pull/1172/files
- https://github.com/yargs/yargs/pull/1554/files

And for historical interest, the addition of `defaultApp` in Electron to work-around the variant behaviour:
- https://github.com/electron/electron/issues/4690#issuecomment-217435222

## Example

```sh
% node -e 'console.log(require(".").parseArgs())' 1 --foo 2 3
{
  args: { foo: true },
  values: { foo: [ undefined ] },
  positionals: [ '1', '2', '3' ]
}
```


```sh
 % node es6.mjs --foo 1 2 3
{
  args: { foo: true },
  values: { foo: [ undefined ] },
  positionals: [ '1', '2', '3' ]
}
```