### PR TITLE
Do not strip excess leading dashes on long option names

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,7 @@ const parseArgs = (
         throw new Error('What are we doing with shortcodes!?!');
       }
 
-      // Any number of leading dashes are allowed
-      // remove all leading dashes
-      arg = arg.replace(/^-+/, '');
+      arg = arg.slice(2); // remove leading --
 
       if (arg.includes('=')) {
         // withValue equals(=) case

--- a/test/index.js
+++ b/test/index.js
@@ -72,7 +72,7 @@ test('excess leading dashes on options are retained', function(t) {
   // Enforce a design decision for an edge case.
   const passedArgs = ['---triple'];
   const passedOptions = { };
-  const expected = { args: { '-triple': true}, values: { '-triple': [undefined]}, positionals: [] };
+  const expected = { flags: { '-triple': true}, values: { '-triple': [undefined]}, positionals: [] };
   const args = parseArgs(passedArgs, passedOptions);
 
   t.deepEqual(args, expected, 'excess option dashes are retained');

--- a/test/index.js
+++ b/test/index.js
@@ -68,6 +68,17 @@ test('args are passed "withValue" and "multiples"', function (t) {
   t.end()
 })
 
+test('excess leading dashes on options are retained', function(t) {
+  // Enforce a design decision for an edge case.
+  const passedArgs = ['---triple'];
+  const passedOptions = { };
+  const expected = { args: { '-triple': true}, values: { '-triple': [undefined]}, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected, 'excess option dashes are retained');
+
+  t.end();
+});
 
 //Test bad inputs
 


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## Problem

All leading dashes on options are being stripped. This was to allow `-foo` treated the same as `--foo` for some circumstances, but that approach is being reconsidered to fully support short option flags and have simple consistent behaviour.

Note: the preflight checks in current limited code mean this is only affecting two or more dashes. 

See #7 and #2

## Solution

Only strip the two leading dashes of an option with two or more leading dashes.

`---foo` is parsed as an option named `-foo`.

(I followed the lint rules for the test file, rather than the local code style. I did not modify the rest of the file to pass the linter to keep this PR focused.)