### PR TITLE
refactor: args to flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ const { parseArgs } = require('util')
 // default
 const argv = ['-f', '--foo=a', '--foo', 'b']
 const options = {}
-const { flags, args, positionals } = parseArgs(argv, options)
+const { flags, values, positionals } = parseArgs(argv, options)
 flags // { f: true, foo: true}
-args // { f: [undefined], foo: [undefined] }
+values // { f: [undefined], foo: [undefined] }
 positionals // ['b']
 ```
 ```js
@@ -111,9 +111,9 @@ const argv = ['-f', '--foo=a', '--foo', 'b']
 const options = {
     withValue: ['foo']
 }
-const { flags, args, positionals } = parseArgs(argv, options)
+const { flags, values, positionals } = parseArgs(argv, options)
 flags // { f: true, foo: true}
-args // { f: [undefined], foo: ['b'] }
+values // { f: [undefined], foo: ['b'] }
 positionals // []
 ```
 ```js
@@ -123,9 +123,9 @@ const options = {
     withValue: ['foo'],
     multiples: ['foo']
 }
-const { flags, args, positionals } = parseArgs(argv, options)
+const { flags, values, positionals } = parseArgs(argv, options)
 flags // { f: true, foo: true}
-args // { f: [undefined], foo: ['a','b'] }
+values // { f: [undefined], foo: ['a','b'] }
 positionals // []
 ```
 ```js
@@ -134,9 +134,9 @@ const argv = ['-f', '--foo=a', '--foo', 'b']
 const options = {
     short: { f: 'foo' }
 }
-const { flags, args, positionals } = parseArgs(argv, options)
+const { flags, values, positionals } = parseArgs(argv, options)
 flags // { foo: true}
-args // { foo: [undefined] }
+values // { foo: [undefined] }
 positionals // ['b']
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ into an `Array`
   * `short` {Object} (Optional) An `Object` of key, value pairs of strings which map a "short" alias to an argument; When appearing multiples times in `argv`; Respects `withValue` & `multiples`
   * `strict` {Boolean} (Optional) A `Boolean` on wheather or not to throw an error when unknown args are encountered
 * Returns: {Object} An object having properties:
-  * `args` {Object}, having properties and `Boolean` values corresponding to parsed options passed
-  * `values` {Object}, have properties and `String` values corresponding to parsed options passed
+  * `flags` {Object}, having properties and `Boolean` values corresponding to parsed options passed
+  * `args` {Object}, have properties and `String` values corresponding to parsed options passed
   * `positionals` {string[]}, containing [Positionals][]
 
 ----
@@ -100,9 +100,9 @@ const { parseArgs } = require('util')
 // default
 const argv = ['-f', '--foo=a', '--foo', 'b']
 const options = {}
-const { args, values, positionals } = parseArgs(argv, options)
-args // { f: true, foo: true}
-values // { f: [undefined], foo: [undefined] }
+const { flags, args, positionals } = parseArgs(argv, options)
+flags // { f: true, foo: true}
+args // { f: [undefined], foo: [undefined] }
 positionals // ['b']
 ```
 ```js
@@ -111,9 +111,9 @@ const argv = ['-f', '--foo=a', '--foo', 'b']
 const options = {
     withValue: ['foo']
 }
-const { args, values, positionals } = parseArgs(argv, options)
-args // { f: true, foo: true}
-values // { f: [undefined], foo: ['b'] }
+const { flags, args, positionals } = parseArgs(argv, options)
+flags // { f: true, foo: true}
+args // { f: [undefined], foo: ['b'] }
 positionals // []
 ```
 ```js
@@ -123,9 +123,9 @@ const options = {
     withValue: ['foo'],
     multiples: ['foo']
 }
-const { args, values, positionals } = parseArgs(argv, options)
-args // { f: true, foo: true}
-values // { f: [undefined], foo: ['a','b'] }
+const { flags, args, positionals } = parseArgs(argv, options)
+flags // { f: true, foo: true}
+args // { f: [undefined], foo: ['a','b'] }
 positionals // []
 ```
 ```js
@@ -134,9 +134,9 @@ const argv = ['-f', '--foo=a', '--foo', 'b']
 const options = {
     short: { f: 'foo' }
 }
-const { args, values, positionals } = parseArgs(argv, options)
-args // { foo: true}
-values // { foo: [undefined] }
+const { flags, args, positionals } = parseArgs(argv, options)
+flags // { foo: true}
+args // { foo: [undefined] }
 positionals // ['b']
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ into an `Array`
   * `strict` {Boolean} (Optional) A `Boolean` on wheather or not to throw an error when unknown args are encountered
 * Returns: {Object} An object having properties:
   * `flags` {Object}, having properties and `Boolean` values corresponding to parsed options passed
-  * `args` {Object}, have properties and `String` values corresponding to parsed options passed
+  * `values` {Object}, have properties and `String` values corresponding to parsed options passed
   * `positionals` {string[]}, containing [Positionals][]
 
 ----

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const parseArgs = (
 
   const result = {
     flags: {},
-    args: {},
+    values: {},
     positionals: []
   };
 
@@ -45,16 +45,16 @@ const parseArgs = (
         const val = options.withValue &&
           options.withValue.includes(argParts[0]) ?
           argParts[1] : undefined;
-        // Append value to previous args array for case of multiples
+        // Append value to previous values array for case of multiples
         // option, else add to empty array
-        result.args[argParts[0]] = [].concat(
+        result.values[argParts[0]] = [].concat(
           options.multiples &&
             options.multiples.includes(argParts[0]) &&
-            result.args[argParts[0]] || [],
+            result.values[argParts[0]] || [],
           val,
         );
       } else if (pos + 1 < argv.length && !argv[pos + 1].startsWith('-')) {
-        // withValue option should also support setting args when '=
+        // withValue option should also support setting values when '=
         // isn't used ie. both --foo=b and --foo b should work
 
         result.flags[arg] = true;
@@ -65,12 +65,12 @@ const parseArgs = (
         const val = options.withValue && options.withValue.includes(arg) ?
           argv[++pos] :
           undefined;
-        // Append value to previous args array for case of multiples
+        // Append value to previous values array for case of multiples
         // option, else add to empty array
-        result.args[arg] = [].concat(
+        result.values[arg] = [].concat(
           options.multiples && options.multiples.includes(arg) &&
-            result.args[arg] ?
-            result.args[arg] :
+            result.values[arg] ?
+            result.values[arg] :
             [],
           val);
       } else {
@@ -78,12 +78,12 @@ const parseArgs = (
         // '--foo --bar' <- 'foo' and 'bar' flags should be set to true and
         // shave value as undefined
         result.flags[arg] = true;
-        // Append undefined to previous args array for case of
+        // Append undefined to previous values array for case of
         // multiples option, else add to empty array
-        result.args[arg] = [].concat(
+        result.values[arg] = [].concat(
           options.multiples && options.multiples.includes(arg) &&
-            result.args[arg] ?
-            result.args[arg] :
+            result.values[arg] ?
+            result.values[arg] :
             [],
           undefined
         );

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ const parseArgs = (
   }
 
   const result = {
+    flags: {},
     args: {},
-    values: {},
     positionals: []
   };
 
@@ -39,25 +39,25 @@ const parseArgs = (
         // withValue equals(=) case
         const argParts = arg.split('=');
 
-        result.args[argParts[0]] = true;
+        result.flags[argParts[0]] = true;
         // If withValue option is specified, take 2nd part after '=' as value,
         // else set value as undefined
         const val = options.withValue &&
           options.withValue.includes(argParts[0]) ?
           argParts[1] : undefined;
-        // Append value to previous arg values array for case of multiples
+        // Append value to previous args array for case of multiples
         // option, else add to empty array
-        result.values[argParts[0]] = [].concat(
+        result.args[argParts[0]] = [].concat(
           options.multiples &&
             options.multiples.includes(argParts[0]) &&
-            result.values[argParts[0]] || [],
+            result.args[argParts[0]] || [],
           val,
         );
       } else if (pos + 1 < argv.length && !argv[pos + 1].startsWith('-')) {
-        // withValue option should also support setting values when '=
+        // withValue option should also support setting args when '=
         // isn't used ie. both --foo=b and --foo b should work
 
-        result.args[arg] = true;
+        result.flags[arg] = true;
         // If withValue option is specified, take next position arguement as
         // value and then increment pos so that we don't re-evaluate that
         // arg, else set value as undefined ie. --foo b --bar c, after setting
@@ -65,25 +65,25 @@ const parseArgs = (
         const val = options.withValue && options.withValue.includes(arg) ?
           argv[++pos] :
           undefined;
-        // Append value to previous arg values array for case of multiples
+        // Append value to previous args array for case of multiples
         // option, else add to empty array
-        result.values[arg] = [].concat(
+        result.args[arg] = [].concat(
           options.multiples && options.multiples.includes(arg) &&
-            result.values[arg] ?
-            result.values[arg] :
+            result.args[arg] ?
+            result.args[arg] :
             [],
           val);
       } else {
         // Cases when an arg is specified without a value, example
-        // '--foo --bar' <- 'foo' and 'bar' args should be set to true and
+        // '--foo --bar' <- 'foo' and 'bar' flags should be set to true and
         // shave value as undefined
-        result.args[arg] = true;
-        // Append undefined to previous arg values array for case of
+        result.flags[arg] = true;
+        // Append undefined to previous args array for case of
         // multiples option, else add to empty array
-        result.values[arg] = [].concat(
+        result.args[arg] = [].concat(
           options.multiples && options.multiples.includes(arg) &&
-            result.values[arg] ?
-            result.values[arg] :
+            result.args[arg] ?
+            result.args[arg] :
             [],
           undefined
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -907,6 +907,13 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "eslint-plugin-markdown": "^2.2.1",
         "eslint-plugin-node-core": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-plugin-node-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-node-core/-/eslint-plugin-node-core-1.0.0.tgz",
+          "integrity": "sha512-1i9imacKER4Noc7AkfgnPfRcirKb9GICuSmmu3q/V2VjsQA4jCYh6cExvpRsdPkX4mQh8tSpoDRrCfE7az04KA=="
+        }
       }
     },
     "eslint-scope": {

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ const {parseArgs} = require('../index.js')
 
 test('Everything after a bare `--` is considered a positional argument', function (t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals']
-  const expected = { args: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] }
+  const expected = { flags: {}, args: {}, positionals: ['barepositionals', 'mopositionals'] }
   const args = parseArgs(passedArgs)
 
   t.deepEqual(args, expected, 'testing bare positionals')
@@ -17,7 +17,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 
 test('args are true', function (t) {
   const passedArgs = ['--foo', '--bar']
-  const expected = { args: { foo: true, bar: true}, values: {foo: [undefined], bar: [undefined]}, positionals: [] }
+  const expected = { flags: { foo: true, bar: true}, args: {foo: [undefined], bar: [undefined]}, positionals: [] }
   const args = parseArgs(passedArgs)
 
   t.deepEqual(args, expected, 'args are true')
@@ -27,7 +27,7 @@ test('args are true', function (t) {
 
 test('arg is true and positional is identified', function (t) {
   const passedArgs = ['--foo=a', '--foo', 'b']
-  const expected = { args: { foo: true}, values: { foo: [undefined]}, positionals: ['b'] }
+  const expected = { flags: { foo: true}, args: { foo: [undefined]}, positionals: ['b'] }
   const args = parseArgs(passedArgs)
 
   t.deepEqual(args, expected, 'arg is true and positional is identified')
@@ -38,7 +38,7 @@ test('arg is true and positional is identified', function (t) {
 test('args equals are passed "withValue"', function (t) {
   const passedArgs = ['--so=wat']
   const passedOptions = { withValue: ['so'] }
-  const expected = { args: { so: true}, values: { so: ["wat"]}, positionals: [] }
+  const expected = { flags: { so: true}, args: { so: ["wat"]}, positionals: [] }
   const args = parseArgs(passedArgs, passedOptions)
 
   t.deepEqual(args, expected, 'arg value is passed')
@@ -49,7 +49,7 @@ test('args equals are passed "withValue"', function (t) {
 test('same arg is passed twice "withValue" and last value is recorded', function (t) {
   const passedArgs = ['--foo=a', '--foo', 'b']
   const passedOptions = { withValue: ['foo'] }
-  const expected = { args: { foo: true}, values: { foo: ['b']}, positionals: [] }
+  const expected = { flags: { foo: true}, args: { foo: ['b']}, positionals: [] }
   const args = parseArgs(passedArgs, passedOptions)
 
   t.deepEqual(args, expected, 'last arg value is passed')
@@ -60,7 +60,7 @@ test('same arg is passed twice "withValue" and last value is recorded', function
 test('args are passed "withValue" and "multiples"', function (t) {
   const passedArgs = ['--foo=a', '--foo', 'b']
   const passedOptions = { withValue: ['foo'], multiples: ['foo'] }
-  const expected = { args: { foo: true}, values: { foo: ['a', 'b']}, positionals: [] }
+  const expected = { flags: { foo: true}, args: { foo: ['a', 'b']}, positionals: [] }
   const args = parseArgs(passedArgs, passedOptions)
 
   t.deepEqual(args, expected, 'both arg values are passed')

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ const {parseArgs} = require('../index.js')
 
 test('Everything after a bare `--` is considered a positional argument', function (t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals']
-  const expected = { flags: {}, args: {}, positionals: ['barepositionals', 'mopositionals'] }
+  const expected = { flags: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] }
   const args = parseArgs(passedArgs)
 
   t.deepEqual(args, expected, 'testing bare positionals')
@@ -17,7 +17,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 
 test('args are true', function (t) {
   const passedArgs = ['--foo', '--bar']
-  const expected = { flags: { foo: true, bar: true}, args: {foo: [undefined], bar: [undefined]}, positionals: [] }
+  const expected = { flags: { foo: true, bar: true}, values: {foo: [undefined], bar: [undefined]}, positionals: [] }
   const args = parseArgs(passedArgs)
 
   t.deepEqual(args, expected, 'args are true')
@@ -27,7 +27,7 @@ test('args are true', function (t) {
 
 test('arg is true and positional is identified', function (t) {
   const passedArgs = ['--foo=a', '--foo', 'b']
-  const expected = { flags: { foo: true}, args: { foo: [undefined]}, positionals: ['b'] }
+  const expected = { flags: { foo: true}, values: { foo: [undefined]}, positionals: ['b'] }
   const args = parseArgs(passedArgs)
 
   t.deepEqual(args, expected, 'arg is true and positional is identified')
@@ -38,7 +38,7 @@ test('arg is true and positional is identified', function (t) {
 test('args equals are passed "withValue"', function (t) {
   const passedArgs = ['--so=wat']
   const passedOptions = { withValue: ['so'] }
-  const expected = { flags: { so: true}, args: { so: ["wat"]}, positionals: [] }
+  const expected = { flags: { so: true}, values: { so: ["wat"]}, positionals: [] }
   const args = parseArgs(passedArgs, passedOptions)
 
   t.deepEqual(args, expected, 'arg value is passed')
@@ -49,7 +49,7 @@ test('args equals are passed "withValue"', function (t) {
 test('same arg is passed twice "withValue" and last value is recorded', function (t) {
   const passedArgs = ['--foo=a', '--foo', 'b']
   const passedOptions = { withValue: ['foo'] }
-  const expected = { flags: { foo: true}, args: { foo: ['b']}, positionals: [] }
+  const expected = { flags: { foo: true}, values: { foo: ['b']}, positionals: [] }
   const args = parseArgs(passedArgs, passedOptions)
 
   t.deepEqual(args, expected, 'last arg value is passed')
@@ -60,7 +60,7 @@ test('same arg is passed twice "withValue" and last value is recorded', function
 test('args are passed "withValue" and "multiples"', function (t) {
   const passedArgs = ['--foo=a', '--foo', 'b']
   const passedOptions = { withValue: ['foo'], multiples: ['foo'] }
-  const expected = { flags: { foo: true}, args: { foo: ['a', 'b']}, positionals: [] }
+  const expected = { flags: { foo: true}, values: { foo: ['a', 'b']}, positionals: [] }
   const args = parseArgs(passedArgs, passedOptions)
 
   t.deepEqual(args, expected, 'both arg values are passed')


### PR DESCRIPTION
Based on #12, and sifting through online conversations [like this](https://unix.stackexchange.com/questions/285575/whats-the-difference-between-a-flag-an-option-and-an-argument), this refactor
proposes using the terminology "args" for options that take arguments,
and "flags" for options that are boolean.

Fixes #12