### PR TITLE
docs: clean up README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,22 @@ const { parseArgs } = require('util')
 
 ```js
 // default
-const argv = ['-f', '--foo=a', '--foo', 'b']
+const argv = ['-f', '--foo=a', '--goo', 'b']
 const options = {}
 const { flags, values, positionals } = parseArgs(argv, options)
-flags // { f: true, foo: true}
-values // { f: [undefined], foo: [undefined] }
+flags // { f: true, goo: true }
+values // { foo: 'a' }
 positionals // ['b']
 ```
 ```js
 // withValue
-const argv = ['-f', '--foo=a', '--foo', 'b']
+const argv = ['-f', '--foo=a', '--goo', 'b']
 const options = {
-    withValue: ['foo']
+    withValue: ['goo']
 }
 const { flags, values, positionals } = parseArgs(argv, options)
-flags // { f: true, foo: true}
-values // { f: [undefined], foo: ['b'] }
+flags // { f: true }
+values // { foo: 'a', goo: 'b' }
 positionals // []
 ```
 ```js
@@ -124,19 +124,19 @@ const options = {
     multiples: ['foo']
 }
 const { flags, values, positionals } = parseArgs(argv, options)
-flags // { f: true, foo: true}
-values // { f: [undefined], foo: ['a','b'] }
+flags // { f: true }
+values // { foo: ['a', 'b'] }
 positionals // []
 ```
 ```js
 // shorts
-const argv = ['-f', '--foo=a', '--foo', 'b']
+const argv = ['-f']
 const options = {
     short: { f: 'foo' }
 }
 const { flags, values, positionals } = parseArgs(argv, options)
-flags // { foo: true}
-values // { foo: [undefined] }
+flags // { foo: true }
+values // {}
 positionals // ['b']
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,22 +98,22 @@ const { parseArgs } = require('util')
 
 ```js
 // default
-const argv = ['-f', '--foo=a', '--goo', 'b']
+const argv = ['-f', '--foo=a', '--bar', 'b']
 const options = {}
 const { flags, values, positionals } = parseArgs(argv, options)
-flags // { f: true, goo: true }
+flags // { f: true, bar: true }
 values // { foo: 'a' }
 positionals // ['b']
 ```
 ```js
 // withValue
-const argv = ['-f', '--foo=a', '--goo', 'b']
+const argv = ['-f', '--foo=a', '--bar', 'b']
 const options = {
-    withValue: ['goo']
+    withValue: ['bar']
 }
 const { flags, values, positionals } = parseArgs(argv, options)
 flags // { f: true }
-values // { foo: 'a', goo: 'b' }
+values // { foo: 'a', bar: 'b' }
 positionals // []
 ```
 ```js

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const { parseArgs } = require('util')
 ```
 
 ```js
-// default
+// unconfigured
 const argv = ['-f', '--foo=a', '--bar', 'b']
 const options = {}
 const { flags, values, positionals } = parseArgs(argv, options)
@@ -130,7 +130,7 @@ positionals // []
 ```
 ```js
 // shorts
-const argv = ['-f']
+const argv = ['-f', 'b']
 const options = {
     short: { f: 'foo' }
 }


### PR DESCRIPTION
- remove option overwrites from repeated options (#14)
- remove array for plain values (#19)
- flags for flags, values for values (#19)

If this is acceptable, happy to update the code to behave accordingly.