### PR TITLE
Update README FAQ with latest plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ positionals // ['b']
 - Do unknown arguments raise an error?  Are they parsed?  Are they treated as positional arguments?
   - no, they are parsed, not treated as positionals
 - Does `--` signal the end of flags/options?
-  - **open question**
-  - If `--` signals the end, is `--` included as a positional?  is `program -- foo` the same as `program foo`?  Are both `{positionals:['foo']}`, or is the first one `{positionals:['--', 'foo']}`?
+  - yes, so `program -- --bar` sets `{positionals:['--bar']}`
+- If `--` is used to signal the end of the options, is `--` included as a positional?
+  - no, so `program -- foo` is the same as `program foo` and sets `{positionals:['foo']}`
 - Does the API specify whether a `--` was present/relevant?
   - no
 - Is `-foo` the same as `--foo`?

--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ positionals // ['b']
 ### F.A.Qs
 
 - Is `cmd --foo=bar baz` the same as `cmd baz --foo=bar`?
-  - Yes, if `withValue: ['foo']`, otherwise no
+  - Yes
 - Does the parser execute a function?
   - no
 - Does the parser execute one of several functions, depending on input?
   - no
 - Can subcommands take options that are distinct from the main command?
-  - no (this might be a problem? at least it's a more definitive "opinion")
+  - no (there is support for positionals, but not subcommands)
 - Does it output generated help when no options match?
   - no
 - Does it generated short usage?  Like: `usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]`
@@ -175,9 +175,9 @@ positionals // ['b']
 - Does it coerce types?
   - no
 - Does `--no-foo` coerce to `--foo=false`?  For all flags?  Only boolean flags?
-  - no, it sets `{args:{'no-foo': true}}`
+  - no, it sets `{flags:{'no-foo': true}}`
 - Is `--foo` the same as `--foo=true`?  Only for known booleans?  Only at the end?
-  - no, `--foo` is the same as `--foo=`
+  - no, `--foo` is a flag and sets `{flags:{'foo': true}}` while `--foo=true` sets a string value `{values:{'foo': 'true'}}`
 - Does it read environment variables?  Ie, is `FOO=1 cmd` the same as `cmd --foo=1`?
   - no
 - Do unknown arguments raise an error?  Are they parsed?  Are they treated as positional arguments?
@@ -188,8 +188,7 @@ positionals // ['b']
 - Does the API specify whether a `--` was present/relevant?
   - no
 - Is `-foo` the same as `--foo`?
-  - yes <-- ! kind of a blocker for shortopts !
-  - Recommend: "No, -foo is shortopts form of --f --o --o" (assuming none are defined, or withValues)
+  - no, `-foo` is a short option group. Assuming just flags, same as `-f -o -o`.
 - Is `---foo` the same as `--foo`?
   - no 
   - the first flag would be parsed as `'-foo'`

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ positionals // ['b']
 - Do unknown arguments raise an error?  Are they parsed?  Are they treated as positional arguments?
   - no, they are parsed, not treated as positionals
 - Does `--` signal the end of flags/options?
-  - yes, so `program -- --bar` sets `{positionals:['--bar']}`
+  - yes, the following arguments are treated as positionals. e.g. `program -- --bar` sets `{positionals:['--bar']}`
 - If `--` is used to signal the end of the options, is `--` included as a positional?
-  - no, so `program -- foo` is the same as `program foo` and sets `{positionals:['foo']}`
+  - no, `program -- foo` is the same as `program foo` and sets `{positionals:['foo']}`
 - Does the API specify whether a `--` was present/relevant?
   - no
 - Is `-foo` the same as `--foo`?

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ const { flags, values, positionals } = parseArgs(argv, options);
 ### F.A.Qs
 
 - Is `cmd --foo=bar baz` the same as `cmd baz --foo=bar`?
-  - Yes
+  - yes
 - Does the parser execute a function?
   - no
 - Does the parser execute one of several functions, depending on input?


### PR DESCRIPTION
Update the README FAQ with changes from #21 and #22, short option group plans from #2, and some updates to speculative or slightly incorrect comments.

I also updated the `--` QA to match the current behaviour. (With which I agree.)