### PR TITLE
refactor: separate out storage of parsed option in results

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,21 @@ function getMainArgs() {
   return ArrayPrototypeSlice(process.argv, 2);
 }
 
+function storeOptionValue(parseOptions, option, value, result) {
+  result.flags[option] = true;
+
+  // Append value to previous values array for case of multiples
+  // option, else add to empty array
+  result.values[option] = ArrayPrototypeConcat(
+    [],
+    parseOptions.multiples &&
+    ArrayPrototypeIncludes(parseOptions.multiples, option) &&
+    result.values[option] ||
+    [],
+    value
+  );
+}
+
 const parseArgs = (
   argv = getMainArgs(),
   options = {}
@@ -89,27 +104,18 @@ const parseArgs = (
         // withValue equals(=) case
         const argParts = StringPrototypeSplit(arg, '=');
 
-        result.flags[argParts[0]] = true;
         // If withValue option is specified, take 2nd part after '=' as value,
         // else set value as undefined
         const val = options.withValue &&
           ArrayPrototypeIncludes(options.withValue, argParts[0]) ?
           argParts[1] : undefined;
-        // Append value to previous values array for case of multiples
-        // option, else add to empty array
-        result.values[argParts[0]] = ArrayPrototypeConcat([],
-                                                          options.multiples &&
-            ArrayPrototypeIncludes(options.multiples, argParts[0]) &&
-            result.values[argParts[0]] || [],
-                                                          val,
-        );
+        storeOptionValue(options, argParts[0], val, result);
       } else if (pos + 1 < argv.length &&
         !StringPrototypeStartsWith(argv[pos + 1], '-')
       ) {
         // withValue option should also support setting values when '=
         // isn't used ie. both --foo=b and --foo b should work
 
-        result.flags[arg] = true;
         // If withValue option is specified, take next position arguement as
         // value and then increment pos so that we don't re-evaluate that
         // arg, else set value as undefined ie. --foo b --bar c, after setting
@@ -117,31 +123,12 @@ const parseArgs = (
         const val = options.withValue &&
           ArrayPrototypeIncludes(options.withValue, arg) ? argv[++pos] :
           undefined;
-        // Append value to previous values array for case of multiples
-        // option, else add to empty array
-        result.values[arg] = ArrayPrototypeConcat(
-          [],
-          options.multiples &&
-          ArrayPrototypeIncludes(options.multiples, arg) &&
-          result.values[arg] ||
-          [],
-          val
-        );
+        storeOptionValue(options, arg, val, result);
       } else {
         // Cases when an arg is specified without a value, example
         // '--foo --bar' <- 'foo' and 'bar' flags should be set to true and
         // shave value as undefined
-        result.flags[arg] = true;
-        // Append undefined to previous values array for case of
-        // multiples option, else add to empty array
-        result.values[arg] = ArrayPrototypeConcat(
-          [],
-          options.multiples &&
-          ArrayPrototypeIncludes(options.multiples, arg) &&
-          result.values[arg] ||
-          [],
-          undefined
-        );
+        storeOptionValue(options, arg, undefined, result);
       }
 
     } else {


### PR DESCRIPTION
Move the code for storing parsed option to its own routine:
- simplify changes to conventions under discussion (e.g.  #19)
- simplify reuse of logic when add short options
- reduce duplicated code

The intent is zero changes in functionality, zero bugs fixes, zero changes to conventions. 

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
