### PR TITLE
fix: only use arrays in results for multiples

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,18 +48,27 @@ function getMainArgs() {
 }
 
 function storeOptionValue(parseOptions, option, value, result) {
+  const multiple = parseOptions.multiples &&
+    StringPrototypeIncludes(parseOptions.multiples, option);
+
+  // Flags
   result.flags[option] = true;
 
-  // Append value to previous values array for case of multiples
-  // option, else add to empty array
-  result.values[option] = ArrayPrototypeConcat(
-    [],
-    parseOptions.multiples &&
-    ArrayPrototypeIncludes(parseOptions.multiples, option) &&
-    result.values[option] ||
-    [],
-    value
-  );
+  // Values
+  if (multiple) {
+    // Always store value in array, including for flags.
+    // result.values[option] starts out not present,
+    // first value is added as new array [newValue],
+    // subsequent values are pushed to existing array.
+    const usedAsFlag = value === undefined;
+    const newValue = usedAsFlag ? true : value;
+    if (result.values[option] !== undefined)
+      ArrayPrototypePush(result.values[option], newValue);
+    else
+      result.values[option] = [newValue];
+  } else {
+    result.values[option] = value;
+  }
 }
 
 const parseArgs = (

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function getMainArgs() {
 
 function storeOptionValue(parseOptions, option, value, result) {
   const multiple = parseOptions.multiples &&
-    StringPrototypeIncludes(parseOptions.multiples, option);
+    ArrayPrototypeIncludes(parseOptions.multiples, option);
 
   // Flags
   result.flags[option] = true;

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,17 @@ test('same arg is passed twice "withValue" and last value is recorded', function
   t.end();
 });
 
+test('first arg passed for "withValue" and "multiples" is in array', function(t) {
+  const passedArgs = ['--foo=a'];
+  const passedOptions = { withValue: ['foo'], multiples: ['foo'] };
+  const expected = { flags: { foo: true }, values: { foo: ['a'] }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected, 'first multiple in array');
+
+  t.end();
+});
+
 test('args are passed "withValue" and "multiples"', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = { withValue: ['foo'], multiples: ['foo'] };

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 
 test('args are true', function(t) {
   const passedArgs = ['--foo', '--bar'];
-  const expected = { flags: { foo: true, bar: true }, values: { foo: [undefined], bar: [undefined] }, positionals: [] };
+  const expected = { flags: { foo: true, bar: true }, values: { foo: undefined, bar: undefined }, positionals: [] };
   const args = parseArgs(passedArgs);
 
   t.deepEqual(args, expected, 'args are true');
@@ -28,7 +28,7 @@ test('args are true', function(t) {
 
 test('arg is true and positional is identified', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
-  const expected = { flags: { foo: true }, values: { foo: [undefined] }, positionals: ['b'] };
+  const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: ['b'] };
   const args = parseArgs(passedArgs);
 
   t.deepEqual(args, expected, 'arg is true and positional is identified');
@@ -39,7 +39,7 @@ test('arg is true and positional is identified', function(t) {
 test('args equals are passed "withValue"', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { withValue: ['so'] };
-  const expected = { flags: { so: true }, values: { so: ['wat'] }, positionals: [] };
+  const expected = { flags: { so: true }, values: { so: 'wat' }, positionals: [] };
   const args = parseArgs(passedArgs, passedOptions);
 
   t.deepEqual(args, expected, 'arg value is passed');
@@ -50,7 +50,7 @@ test('args equals are passed "withValue"', function(t) {
 test('same arg is passed twice "withValue" and last value is recorded', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = { withValue: ['foo'] };
-  const expected = { flags: { foo: true }, values: { foo: ['b'] }, positionals: [] };
+  const expected = { flags: { foo: true }, values: { foo: 'b' }, positionals: [] };
   const args = parseArgs(passedArgs, passedOptions);
 
   t.deepEqual(args, expected, 'last arg value is passed');
@@ -77,7 +77,7 @@ test('correct default args when use node -p', function(t) {
   const result = parseArgs();
 
   const expected = { flags: { foo: true },
-                     values: { foo: [undefined] },
+                     values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -94,7 +94,7 @@ test('correct default args when use node --print', function(t) {
   const result = parseArgs();
 
   const expected = { flags: { foo: true },
-                     values: { foo: [undefined] },
+                     values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -111,7 +111,7 @@ test('correct default args when use node -e', function(t) {
   const result = parseArgs();
 
   const expected = { flags: { foo: true },
-                     values: { foo: [undefined] },
+                     values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -128,7 +128,7 @@ test('correct default args when use node --eval', function(t) {
   const result = parseArgs();
 
   const expected = { flags: { foo: true },
-                     values: { foo: [undefined] },
+                     values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -145,7 +145,7 @@ test('correct default args when normal arguments', function(t) {
   const result = parseArgs();
 
   const expected = { flags: { foo: true },
-                     values: { foo: [undefined] },
+                     values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -160,7 +160,7 @@ test('excess leading dashes on options are retained', function(t) {
   const passedOptions = { };
   const expected = {
     flags: { '-triple': true },
-    values: { '-triple': [undefined] },
+    values: { '-triple': undefined },
     positionals: []
   };
   const result = parseArgs(passedArgs, passedOptions);


### PR DESCRIPTION
In the old parse results, `values[option]` is always an array whether or not `multiple` is used. This PR makes it so an array is not used unless the option is listed in `multiple`, in which case `values[option]` is an array from the first value added.

Fixes #19

(Code previously proposed and reviewed in #26, so will look familiar logic to some.)

Side note. `multiples` does not make the `values` start with an empty array because:

- we don't do defaults for other options
- an empty array would make detecting whether the option has been used different for a `multiple`

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
