### PR TITLE
fix: always store value for a=b

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const {
   ArrayPrototypePush,
   StringPrototypeCharAt,
   StringPrototypeIncludes,
+  StringPrototypeIndexOf,
   StringPrototypeSlice,
-  StringPrototypeSplit,
   StringPrototypeStartsWith,
 } = require('./primordials');
 
@@ -101,15 +101,16 @@ const parseArgs = (
       arg = StringPrototypeSlice(arg, 2); // remove leading --
 
       if (StringPrototypeIncludes(arg, '=')) {
-        // withValue equals(=) case
-        const argParts = StringPrototypeSplit(arg, '=');
-
-        // If withValue option is specified, take 2nd part after '=' as value,
-        // else set value as undefined
-        const val = options.withValue &&
-          ArrayPrototypeIncludes(options.withValue, argParts[0]) ?
-          argParts[1] : undefined;
-        storeOptionValue(options, argParts[0], val, result);
+        // Store option=value same way independent of `withValue` as:
+        // - looks like a value, store as a value
+        // - match the intention of the user
+        // - preserve information for author to process further
+        const index = StringPrototypeIndexOf(arg, '=');
+        storeOptionValue(
+          options,
+          StringPrototypeSlice(arg, 0, index),
+          StringPrototypeSlice(arg, index + 1),
+          result);
       } else if (pos + 1 < argv.length &&
         !StringPrototypeStartsWith(argv[pos + 1], '-')
       ) {

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,17 @@ test('args equals are passed "withValue"', function(t) {
   t.end();
 });
 
+test('zero config args equals are parsed as if "withValue"', function(t) {
+  const passedArgs = ['--so=wat'];
+  const passedOptions = { };
+  const expected = { flags: { so: true }, values: { so: ['wat'] }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected, 'arg value is passed');
+
+  t.end();
+});
+
 test('same arg is passed twice "withValue" and last value is recorded', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = { withValue: ['foo'] };
@@ -54,6 +65,17 @@ test('same arg is passed twice "withValue" and last value is recorded', function
   const args = parseArgs(passedArgs, passedOptions);
 
   t.deepEqual(args, expected, 'last arg value is passed');
+
+  t.end();
+});
+
+test('args equals pass string including more equals', function(t) {
+  const passedArgs = ['--so=wat=bing'];
+  const passedOptions = { withValue: ['so'] };
+  const expected = { flags: { so: true }, values: { so: ['wat=bing'] }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected, 'arg value is passed');
 
   t.end();
 });


### PR DESCRIPTION
This actually has two fixes in just two statements. They overlap, so not separate PR. :-)

The big change is always store the value for `--foo=value`, even for zero-config. See #24 for discussion to support this. This approach:
- reflects user intent
- preserves information for author curation
- does not introduce a new pattern in the shape of the result

Closes #24.

The small fix is `--foo=b=c` stores the value `b=c` (previously was ignoring text from the second equals onwards).

(Code previously proposed and reviewed in #26, so will look familiar logic to some.)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
