### PR TITLE
docs: ordering of positional and option does not matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ const { flags, values, positionals } = parseArgs(argv, options);
 ### F.A.Qs
 
 - Is `cmd --foo=bar baz` the same as `cmd baz --foo=bar`?
-  - Yes, if `withValue: ['foo']`, otherwise no
+  - yes
 - Does the parser execute a function?
   - no
 - Does the parser execute one of several functions, depending on input?

--- a/test/index.js
+++ b/test/index.js
@@ -80,6 +80,18 @@ test('args are passed "withValue" and "multiples"', function(t) {
   t.end();
 });
 
+test('order of option and positional does not matter (per README)', function(t) {
+  const passedArgs1 = ['--foo=bar', 'baz'];
+  const passedArgs2 = ['baz', '--foo=bar'];
+  const passedOptions = { withValue: ['foo'] };
+  const expected = { flags: { foo: true }, values: { foo: 'bar' }, positionals: ['baz'] };
+
+  t.deepEqual(parseArgs(passedArgs1, passedOptions), expected, 'option then positional');
+  t.deepEqual(parseArgs(passedArgs2, passedOptions), expected, 'positional then option');
+
+  t.end();
+});
+
 test('correct default args when use node -p', function(t) {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];


### PR DESCRIPTION
Options can come before or after positional. The option type does not matter for the example given.

(If it is an error or some snowflake result because not `withValue`, it will still behave the same for both argument orders!)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
