### PR TITLE
docs: no subcommands, no worries

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ const { flags, values, positionals } = parseArgs(argv, options);
 - Does the parser execute one of several functions, depending on input?
   - no
 - Can subcommands take options that are distinct from the main command?
-  - no (this might be a problem? at least it's a more definitive "opinion")
+  - no
 - Does it output generated help when no options match?
   - no
 - Does it generated short usage?  Like: `usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]`


### PR DESCRIPTION
We have lots of problems, but lack of subcommands is not one of them. 🤣 

Support for subcommands has not come up in issues or discussion, so not worth continuing to qualify in README. Just saying no covers it fine.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
