### PR TITLE
docs: clarify short options hopefully coming

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,7 @@ const { flags, values, positionals } = parseArgs(argv, options);
 - Does the API specify whether a `--` was present/relevant?
   - no
 - Is `-foo` the same as `--foo`?
-  - yes <-- ! kind of a blocker for shortopts !
-  - Recommend: "No, -foo is shortopts form of --f --o --o" (assuming none are defined, or withValues)
+  - no, `-foo` is a short option or options (WIP: https://github.com/pkgjs/parseargs/issues/2)
 - Is `---foo` the same as `--foo`?
   - no 
   - the first flag would be parsed as `'-foo'`


### PR DESCRIPTION
We do not want `-foo` to be the same as `--foo`. That much is fairly certain.

`-foo` is likely to be the same as `-f -o -o`, at least when plain flags. But nothing implemented yet, so point to issue rather than speculate.

See #2

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
