### PR TITLE
feat: basic support for shorts

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,13 +113,19 @@ const parseArgs = (
           ArrayPrototypeSlice(argv, ++pos)
         );
         return result;
-      } else if (
-        StringPrototypeCharAt(arg, 1) !== '-'
-      ) { // Look for shortcodes: -fXzy
-        throw new ERR_NOT_IMPLEMENTED('shortcodes');
-      }
+      } else if (StringPrototypeCharAt(arg, 1) !== '-') {
+        // Look for shortcodes: -fXzy
+        if (arg.length > 2) {
+          throw new ERR_NOT_IMPLEMENTED('short option groups');
+        }
 
-      arg = StringPrototypeSlice(arg, 2); // remove leading --
+        arg = StringPrototypeCharAt(arg, 1); // short
+        if (options.short && options.short[arg])
+          arg = options.short[arg]; // now long!
+        // ToDo: later code tests for `=` in arg and wrong for shorts
+      } else {
+        arg = StringPrototypeSlice(arg, 2); // remove leading --
+      }
 
       if (StringPrototypeIncludes(arg, '=')) {
         // Store option=value same way independent of `withValue` as:

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,70 @@ const { parseArgs } = require('../index.js');
 
 // Test results are as we expect
 
+test('when short option used as flag then stored as flag', function(t) {
+  const passedArgs = ['-f'];
+  const expected = { flags: { f: true }, values: { f: undefined }, positionals: [] };
+  const args = parseArgs(passedArgs);
+
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('when short option used as flag before positional then stored as flag and positional (and not value)', function(t) {
+  const passedArgs = ['-f', 'bar'];
+  const expected = { flags: { f: true }, values: { f: undefined }, positionals: [ 'bar' ] };
+  const args = parseArgs(passedArgs);
+
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('when short option withValue used with value then stored as value', function(t) {
+  const passedArgs = ['-f', 'bar'];
+  const passedOptions = { withValue: ['f'] };
+  const expected = { flags: { f: true }, values: { f: 'bar' }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('when short option listed in short used as flag then long option stored as flag', function(t) {
+  const passedArgs = ['-f'];
+  const passedOptions = { short: { f: 'foo' } };
+  const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('when short option listed in short and long listed in withValue and used with value then long option stored as value', function(t) {
+  const passedArgs = ['-f', 'bar'];
+  const passedOptions = { short: { f: 'foo' }, withValue: ['foo'] };
+  const expected = { flags: { foo: true }, values: { foo: 'bar' }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('when short option withValue used without value then stored as flag', function(t) {
+  const passedArgs = ['-f'];
+  const passedOptions = { withValue: ['f'] };
+  const expected = { flags: { f: true }, values: { f: undefined }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
 test('Everything after a bare `--` is considered a positional argument', function(t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals'];
   const expected = { flags: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };


### PR DESCRIPTION
Make a start on support for short options.

Handle single character short, and lookup long option in `short` configuration if present.

(Keeping code local to minimise conflicts at present. Changes still overlap with #40.)

First phase of implementing #2.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
