### PR TITLE
feat(typescript): add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,12 @@
+interface Dictionary<T = any> {
+  [key: string]: T;
+}
+export interface Options {
+  withValue?: string[]
+}
+export interface Argv {
+  flags: Dictionary<boolean>;
+  values: Dictionary<string>;
+  positionals: string[];
+}
+export function parseArgs(argv?: string[] | Options, options?: Options): Argv;


### PR DESCRIPTION
Add Type Definitions, in pursuit of creating shim that has feature parity with yargs-parser.