### PR TITLE
feat: use Map rather than Object for internal result properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,11 @@ const {
   ArrayPrototypeIncludes,
   ArrayPrototypeSlice,
   ArrayPrototypePush,
+  MapPrototypeGet,
+  MapPrototypeHas,
+  MapPrototypeSet,
   ObjectHasOwn,
+  ObjectFromEntries,
   StringPrototypeCharAt,
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
@@ -63,7 +67,7 @@ function storeOptionValue(parseOptions, option, value, result) {
     ArrayPrototypeIncludes(parseOptions.multiples, option);
 
   // Flags
-  result.flags[option] = true;
+  MapPrototypeSet(result.flags, option, true);
 
   // Values
   if (multiple) {
@@ -73,12 +77,12 @@ function storeOptionValue(parseOptions, option, value, result) {
     // subsequent values are pushed to existing array.
     const usedAsFlag = value === undefined;
     const newValue = usedAsFlag ? true : value;
-    if (result.values[option] !== undefined)
-      ArrayPrototypePush(result.values[option], newValue);
+    if (MapPrototypeHas(result.values, option))
+      ArrayPrototypePush(MapPrototypeGet(result.values, option), newValue);
     else
-      result.values[option] = [newValue];
+      MapPrototypeSet(result.values, option, [newValue]);
   } else {
-    result.values[option] = value;
+    MapPrototypeSet(result.values, option, value);
   }
 }
 
@@ -95,8 +99,8 @@ const parseArgs = (
   }
 
   const result = {
-    flags: {},
-    values: {},
+    flags: new Map(),
+    values: new Map(),
     positionals: []
   };
 
@@ -112,7 +116,8 @@ const parseArgs = (
           result.positionals,
           ArrayPrototypeSlice(argv, ++pos)
         );
-        return result;
+        pos = argv.length;
+        continue;
       } else if (StringPrototypeCharAt(arg, 1) !== '-') {
         // Look for shortcodes: -fXzy
         if (arg.length > 2) {
@@ -167,7 +172,12 @@ const parseArgs = (
     pos++;
   }
 
-  return result;
+  const clientResult = {
+    flags: ObjectFromEntries(result.flags),
+    values: ObjectFromEntries(result.values),
+    positionals: result.positionals
+  };
+  return clientResult;
 };
 
 module.exports = {


### PR DESCRIPTION
This came out of discussion around potential for prototype pollution. Use a Map rather than Object internally. Convert to Object for returning to client.

See https://github.com/pkgjs/parseargs/issues/32#issuecomment-1013948553

(Why not use `Set` for `flags`? Could, but a little easier to convert from `Map` to `Object`!)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
