### PR TITLE
feat(parser): support short-option groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ const { flags, values, positionals } = parseArgs(argv, options);
   - no
 - Is `-foo` the same as `--foo`?
   - no, `-foo` is a short option or options, with expansion logic that follows the
-    [Utility Syntax Guidelines in POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html). `--foo bar`, `withValue: ['foo']`, expands to `-f`, `-o`, `-o bar`.
+    [Utility Syntax Guidelines in POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html). `-bar` expands to `-b`, `-a`, `-r`.
 - Is `---foo` the same as `--foo`?
   - no 
   - the first flag would be parsed as `'-foo'`

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ const { flags, values, positionals } = parseArgs(argv, options);
   - If `--` signals the end, is `--` included as a positional?  is `program -- foo` the same as `program foo`?  Are both `{positionals:['foo']}`, or is the first one `{positionals:['--', 'foo']}`?
 - Does the API specify whether a `--` was present/relevant?
   - no
-- Is `-foo` the same as `--foo`?
+- Is `-bar` the same as `--bar`?
   - no, `-foo` is a short option or options, with expansion logic that follows the
     [Utility Syntax Guidelines in POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html). `-bar` expands to `-b`, `-a`, `-r`.
 - Is `---foo` the same as `--foo`?

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ const { flags, values, positionals } = parseArgs(argv, options);
 - Does the API specify whether a `--` was present/relevant?
   - no
 - Is `-foo` the same as `--foo`?
-  - no, `-foo` is a short option or options (WIP: https://github.com/pkgjs/parseargs/issues/2)
+  - no, `-foo` is a short option or options, with expansion logic that follows the
+    [Utility Syntax Guidelines in POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html). `--foo bar`, `withValue: ['foo']`, expands to `-f`, `-o`, `-o bar`.
 - Is `---foo` the same as `--foo`?
   - no 
   - the first flag would be parsed as `'-foo'`

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ const { flags, values, positionals } = parseArgs(argv, options);
 - Does the API specify whether a `--` was present/relevant?
   - no
 - Is `-bar` the same as `--bar`?
-  - no, `-foo` is a short option or options, with expansion logic that follows the
+  - no, `-bar` is a short option or options, with expansion logic that follows the
     [Utility Syntax Guidelines in POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html). `-bar` expands to `-b`, `-a`, `-r`.
 - Is `---foo` the same as `--foo`?
   - no 

--- a/errors.js
+++ b/errors.js
@@ -7,16 +7,8 @@ class ERR_INVALID_ARG_TYPE extends TypeError {
   }
 }
 
-class ERR_NOT_IMPLEMENTED extends Error {
-  constructor(feature) {
-    super(`${feature} not implemented`);
-    this.code = 'ERR_NOT_IMPLEMENTED';
-  }
-}
-
 module.exports = {
   codes: {
     ERR_INVALID_ARG_TYPE,
-    ERR_NOT_IMPLEMENTED
   }
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const {
   ArrayPrototypeConcat,
   ArrayPrototypeIncludes,
   ArrayPrototypeSlice,
+  ArrayPrototypeSplice,
   ArrayPrototypePush,
   ObjectHasOwn,
   StringPrototypeCharAt,
@@ -12,12 +13,6 @@ const {
   StringPrototypeSlice,
   StringPrototypeStartsWith,
 } = require('./primordials');
-
-const {
-  codes: {
-    ERR_NOT_IMPLEMENTED
-  }
-} = require('./errors');
 
 const {
   validateArray,
@@ -119,9 +114,14 @@ const parseArgs = (
         );
         return result;
       } else if (StringPrototypeCharAt(arg, 1) !== '-') {
-        // Look for shortcodes: -fXzy
+        // Look for shortcodes: -fXzy and expand them to -f -X -z -y:
         if (arg.length > 2) {
-          throw new ERR_NOT_IMPLEMENTED('short option groups');
+          for (let i = 2; i < arg.length; i++) {
+            const short = StringPrototypeCharAt(arg, i);
+            // Add 'i' to 'pos' such that short options are parsed in order
+            // of definition:
+            ArrayPrototypeSplice(argv, pos + (i - 1), 0, `-${short}`);
+          }
         }
 
         arg = StringPrototypeCharAt(arg, 1); // short

--- a/test/index.js
+++ b/test/index.js
@@ -70,6 +70,58 @@ test('when short option withValue used without value then stored as flag', funct
   t.end();
 });
 
+test('short option group behaves like multiple short options', function(t) {
+  const passedArgs = ['-rf'];
+  const passedOptions = { };
+  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('short option group does not consume subsequent positional', function(t) {
+  const passedArgs = ['-rf', 'foo'];
+  const passedOptions = { };
+  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['foo'] };
+  const args = parseArgs(passedArgs, passedOptions);
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+// See: Guideline 5 https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
+test('if terminal of short-option group configured withValue, subsequent positional is stored', function(t) {
+  const passedArgs = ['-rvf', 'foo'];
+  const passedOptions = { withValue: ['f'] };
+  const expected = { flags: { r: true, f: true, v: true }, values: { r: undefined, v: undefined, f: 'foo' }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('handles short-option groups in conjunction with long-options', function(t) {
+  const passedArgs = ['-rf', '--foo', 'foo'];
+  const passedOptions = { withValue: ['foo'] };
+  const expected = { flags: { r: true, f: true, foo: true }, values: { r: undefined, f: undefined, foo: 'foo' }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('handles short-option groups with "short" alias configured', function(t) {
+  const passedArgs = ['-rf'];
+  const passedOptions = { short: { r: 'remove' } };
+  const expected = { flags: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
+  const args = parseArgs(passedArgs, passedOptions);
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
 test('Everything after a bare `--` is considered a positional argument', function(t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals'];
   const expected = { flags: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };


### PR DESCRIPTION
This is a proposal for supporting short option groups that is quite simple (which I like), and at the same time agrees with an edge-case documented in `yargs-parser` -- which make me think it's a reasonable approach (_I at least haven't noticed many folks complain about this edge-case in the past_).

## The implementation

Quite simply, `-foo` expands out to `-f`, `-o`, `-o`, and each individual value is handled by the next step in the parser.

The interesting edge-case of this is that if `withValue` is configured for the terminal value in the short option list, and the short-option list is followed by a positional, it will be consumed:

```js
const passedArgs = ['-rf', 'foo'];
const passedOptions = { withValue: ['f'] };
const expected = { flags: { r: true, f: true }, values: { r: undefined, f: 'foo' }, positionals: [] };
const args = parseArgs(passedArgs, passedOptions);
```

As mentioned, this behavior agrees with unit tests in `yargs-parser`:

```js
// from yargs' test suite:
it('should set the value of the final option in a group to the next supplied value', function () {
    const parse = parser(['-cats', 'meow'])
    parse.should.have.property('c', true)
    parse.should.have.property('a', true)
    parse.should.have.property('t', true)
    parse.should.have.property('s', 'meow')
    parse.should.have.property('_').with.length(0)
})
```

~TODO: document this decision in README.~
Fixes #2