### PR TITLE
Fix typos in comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ const parseArgs = (
         // withValue option should also support setting values when '=
         // isn't used ie. both --foo=b and --foo b should work
 
-        // If withValue option is specified, take next position arguement as
+        // If withValue option is specified, take next position argument as
         // value and then increment pos so that we don't re-evaluate that
         // arg, else set value as undefined ie. --foo b --bar c, after setting
         // b as the value for foo, evaluate --bar next and skip 'b'
@@ -160,12 +160,12 @@ const parseArgs = (
       } else {
         // Cases when an arg is specified without a value, example
         // '--foo --bar' <- 'foo' and 'bar' flags should be set to true and
-        // shave value as undefined
+        // save value as undefined
         storeOptionValue(options, arg, undefined, result);
       }
 
     } else {
-      // Arguements without a dash prefix are considered "positional"
+      // Arguments without a dash prefix are considered "positional"
       ArrayPrototypePush(result.positionals, arg);
     }
 


### PR DESCRIPTION
Fix a few typos I keep noticing (and separately from any code PR which may or may not land).

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
