### PR TITLE
feat: short with value in same arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const {
   ArrayPrototypeConcat,
   ArrayPrototypeIncludes,
+  ArrayPrototypeMap,
   ArrayPrototypeSlice,
   ArrayPrototypeSplice,
   ArrayPrototypePush,
@@ -127,10 +128,7 @@ const parseArgs = (
 
     if (isShortOptionGroup(arg, options)) {
       // Expand -fXzy to -f -X -z -y
-      const expanded = [];
-      for (let index = 1; index < arg.length; index++) {
-        ArrayPrototypePush(expanded, `-${StringPrototypeCharAt(arg, index)}`);
-      }
+      const expanded = ArrayPrototypeMap(StringPrototypeSlice(arg, 1), (char) => `-${char}`);
       // Replace group with expansion.
       ArrayPrototypeSplice(argv, pos, 1, ...expanded);
       continue;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypeConcat,
+  ArrayPrototypeEvery,
   ArrayPrototypeIncludes,
   ArrayPrototypeMap,
   ArrayPrototypeSlice,
@@ -192,14 +193,12 @@ function isShortOptionGroup(arg, options) {
   if (StringPrototypeCharAt(arg, 0) !== '-') return false;
   if (StringPrototypeCharAt(arg, 1) === '-') return false;
 
-  const onlyFlags = StringPrototypeSlice(arg, 1, -1);
-  for (let index = 0; index < onlyFlags.length; index++) {
-    const optionKey = getOptionKey(StringPrototypeCharAt(onlyFlags, index));
-    if (isExpectingValue(optionKey, options)) {
-      return false;
-    }
-  }
-  return true;
+  const leadingShorts = StringPrototypeSlice(arg, 1, -1);
+  const allLeadingAreBoolean = ArrayPrototypeEvery(leadingShorts, (short) => {
+    const optionKey = getOptionKey(short);
+    return !isExpectingValue(optionKey, options);
+  });
+  return allLeadingAreBoolean;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const {
   ArrayPrototypeIncludes,
   ArrayPrototypeMap,
   ArrayPrototypeSlice,
-  ArrayPrototypeSplice,
   ArrayPrototypePush,
   ObjectHasOwn,
   StringPrototypeCharAt,
@@ -131,7 +130,11 @@ const parseArgs = (
       // Expand -fXzy to -f -X -z -y
       const expanded = ArrayPrototypeMap(StringPrototypeSlice(arg, 1), (char) => `-${char}`);
       // Replace group with expansion.
-      ArrayPrototypeSplice(argv, pos, 1, ...expanded);
+      argv = ArrayPrototypeConcat(
+        ArrayPrototypeSlice(argv, 0, pos),
+        expanded,
+        ArrayPrototypeSlice(argv, pos + 1),
+      );
       continue;
     }
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ const parseArgs = (
       continue;
     }
 
-    if (isShortOptionGroup(arg)) {
+    if (isShortOptionGroup(arg, options)) {
       // Expand -fXzy to -f -X -z -y
       const expanded = [];
       for (let index = 1; index < arg.length; index++) {
@@ -197,7 +197,7 @@ function isShortOptionGroup(arg, options) {
   const onlyFlags = arg.slice(1, -1);
   for (let index = 0; index < onlyFlags.length; index++) {
     const optionKey = getOptionKey(StringPrototypeCharAt(onlyFlags, index));
-    if (isExpectingValue(optionKey)) {
+    if (isExpectingValue(optionKey, options)) {
       return false;
     }
   }

--- a/index.js
+++ b/index.js
@@ -138,6 +138,15 @@ const parseArgs = (
       continue;
     }
 
+    if (isShortAndValue(arg, options)) {
+      // e.g. '-fBAR'
+      const optionKey = getOptionKey(StringPrototypeCharAt(arg, 1), options);
+      const optionValue = StringPrototypeSlice(arg, 2);
+      storeOptionValue(optionKey, optionValue, options, result);
+      pos++;
+      continue;
+    }
+
     if (isLongOption(arg)) {
       let optionKey;
       let optionValue;
@@ -203,6 +212,20 @@ function isShortOptionGroup(arg, options) {
   });
   return allLeadingAreBoolean;
 }
+
+/**
+  * Determines if `arg` is a combined short option and its value.
+  * @example '-fBAR'
+  */
+function isShortAndValue(arg, options) {
+  if (arg.length <= 2) return false;
+  if (StringPrototypeCharAt(arg, 0) !== '-') return false;
+  if (StringPrototypeCharAt(arg, 1) === '-') return false;
+
+  const optionKey = getOptionKey(StringPrototypeCharAt(arg, 1), options);
+  return isExpectingValue(optionKey, options);
+}
+
 
 /**
   * Determines if `arg` is a long option, which may have a trailing value.

--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function isShortOptionGroup(arg, options) {
   if (StringPrototypeCharAt(arg, 0) !== '-') return false;
   if (StringPrototypeCharAt(arg, 1) === '-') return false;
 
-  const onlyFlags = arg.slice(1, -1);
+  const onlyFlags = StringPrototypeSlice(arg, 1, -1);
   for (let index = 0; index < onlyFlags.length; index++) {
     const optionKey = getOptionKey(StringPrototypeCharAt(onlyFlags, index));
     if (isExpectingValue(optionKey, options)) {

--- a/index.js
+++ b/index.js
@@ -186,8 +186,8 @@ function isLoneShortOption(arg) {
   * @example
   * isShortOptionGroup('-a', {}) // returns false
   * isShortOptionGroup('-ab', {}) // returns true
-  * isShortOptionGroup('-fb', { withValues: ['f'] }) // returns false
-  * isShortOptionGroup('-bf', { withValues: ['f'] }) // returns true
+  * isShortOptionGroup('-fb', { withValue: ['f'] }) // returns false
+  * isShortOptionGroup('-bf', { withValue: ['f'] }) // returns true
   */
 function isShortOptionGroup(arg, options) {
   if (arg.length <= 2) return false;

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ function isShortOptionGroup(arg, options) {
 
   const leadingShorts = StringPrototypeSlice(arg, 1, -1);
   const allLeadingAreBoolean = ArrayPrototypeEvery(leadingShorts, (short) => {
-    const optionKey = getOptionKey(short);
+    const optionKey = getOptionKey(short, options);
     return !isExpectingValue(optionKey, options);
   });
   return allLeadingAreBoolean;

--- a/index.js
+++ b/index.js
@@ -239,11 +239,12 @@ function isExpectingValue(optionKey, options) {
 
 /**
   * Determines if the argument can be used as an option value.
-  * NB: We are choosing not to accept option-looking arguments.
+  * NB: We are choosing not to accept option-ish arguments.
   * @example
-  * isOptionValue(['-v', 'V'], 1) // returns true
-  * isOptionValue(['-v'], 1) // returns false
-  * isOptionValue(['-v', '-b'], 1) // returns false
+  * isOptionValue('V']) // returns true
+  * isOptionValue('-v') // returns false
+  * isOptionValue('--foo') // returns false
+  * isOptionValue(undefined) // returns false
   */
 function isOptionValue(value) {
   if (value === undefined) return false;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Polyfill of future proposal for `util.parseArgs()`",
   "main": "index.js",
   "scripts": {
-    "coverage": "c8 --check-coverage node test/index.js",
-    "test": "c8 node test/index.js",
+    "coverage": "c8 --check-coverage tape 'test/*.js'",
+    "test": "c8 tape 'test/*.js'",
     "posttest": "eslint .",
     "fix": "npm run posttest -- --fix"
   },

--- a/test/dash.js
+++ b/test/dash.js
@@ -19,7 +19,7 @@ test("when args include '-' used as positional then result has '-' in positional
 });
 
 // If '-' is a valid positional, it is symmetrical to allow it as an option value too.
-test("when args include '-' used as option value then result has '-' in option value", function(t) {
+test("when args include '-' used as space-separated option value then result has '-' in option value", function(t) {
   const passedArgs = ['-v', '-'];
   const options = { withValue: ['v'] };
 

--- a/test/dash.js
+++ b/test/dash.js
@@ -1,0 +1,31 @@
+'use strict';
+/* eslint max-len: 0 */
+
+const test = require('tape');
+const { parseArgs } = require('../index.js');
+
+// The use of `-` as a positional is specifically mentioned in the Open Group Utility Conventions.
+// The interpretation is up to the utility, and for a file positional (operand) the examples are
+// '-' may stand for standard input (or standard output), or for a file named -.
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
+test("when args include '-' used as positional then result has '-' in positionals", function(t) {
+  const passedArgs = ['-'];
+
+  const args = parseArgs(passedArgs);
+  const expected = { flags: {}, values: {}, positionals: ['-'] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+// If '-' is a valid positional, it is symmetrical to allow it as an option value too.
+test("when args include '-' used as option value then result has '-' in option value", function(t) {
+  const passedArgs = ['-v', '-'];
+  const options = { withValue: ['v'] };
+
+  const args = parseArgs(passedArgs, options);
+  const expected = { flags: { v: true }, values: { v: '-' }, positionals: [] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -163,16 +163,6 @@ test('args equals are passed "withValue"', function(t) {
   t.end();
 });
 
-test('when args include single dash then result stores dash as positional', function(t) {
-  const passedArgs = ['-'];
-  const expected = { flags: { }, values: { }, positionals: ['-'] };
-  const args = parseArgs(passedArgs);
-
-  t.deepEqual(args, expected);
-
-  t.end();
-});
-
 test('zero config args equals are parsed as if "withValue"', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { };

--- a/test/index.js
+++ b/test/index.js
@@ -70,58 +70,6 @@ test('when short option withValue used without value then stored as flag', funct
   t.end();
 });
 
-test('short option group behaves like multiple short options', function(t) {
-  const passedArgs = ['-rf'];
-  const passedOptions = { };
-  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: [] };
-  const args = parseArgs(passedArgs, passedOptions);
-
-  t.deepEqual(args, expected);
-
-  t.end();
-});
-
-test('short option group does not consume subsequent positional', function(t) {
-  const passedArgs = ['-rf', 'foo'];
-  const passedOptions = { };
-  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['foo'] };
-  const args = parseArgs(passedArgs, passedOptions);
-  t.deepEqual(args, expected);
-
-  t.end();
-});
-
-// See: Guideline 5 https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
-test('if terminal of short-option group configured withValue, subsequent positional is stored', function(t) {
-  const passedArgs = ['-rvf', 'foo'];
-  const passedOptions = { withValue: ['f'] };
-  const expected = { flags: { r: true, f: true, v: true }, values: { r: undefined, v: undefined, f: 'foo' }, positionals: [] };
-  const args = parseArgs(passedArgs, passedOptions);
-  t.deepEqual(args, expected);
-
-  t.end();
-});
-
-test('handles short-option groups in conjunction with long-options', function(t) {
-  const passedArgs = ['-rf', '--foo', 'foo'];
-  const passedOptions = { withValue: ['foo'] };
-  const expected = { flags: { r: true, f: true, foo: true }, values: { r: undefined, f: undefined, foo: 'foo' }, positionals: [] };
-  const args = parseArgs(passedArgs, passedOptions);
-  t.deepEqual(args, expected);
-
-  t.end();
-});
-
-test('handles short-option groups with "short" alias configured', function(t) {
-  const passedArgs = ['-rf'];
-  const passedOptions = { short: { r: 'remove' } };
-  const expected = { flags: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
-  const args = parseArgs(passedArgs, passedOptions);
-  t.deepEqual(args, expected);
-
-  t.end();
-});
-
 test('Everything after a bare `--` is considered a positional argument', function(t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals'];
   const expected = { flags: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };

--- a/test/short-option-group.js
+++ b/test/short-option-group.js
@@ -1,0 +1,72 @@
+'use strict';
+/* eslint max-len: 0 */
+
+const test = require('tape');
+const { parseArgs } = require('../index.js');
+
+test('when short option group of zero-config flags then result same as expanded options', function(t) {
+  const passedArgs = ['-rf'];
+  const passedOptions = { };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: [] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('short option group of flags does not consume subsequent positional', function(t) {
+  const passedArgs = ['-rf', 'foo'];
+  const passedOptions = { };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['foo'] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+// See: Guideline 5 https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
+test('when terminal of short-option group expects value then subsequent argument is stored as value', function(t) {
+  const passedArgs = ['-rvf', 'foo'];
+  const passedOptions = { withValue: ['f'] };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: { r: true, f: true, v: true }, values: { r: undefined, v: undefined, f: 'foo' }, positionals: [] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('when middle of short-option group expects value then arg returned as positional (as not a valid group)', function(t) {
+  const passedArgs = ['-afb'];
+  const passedOptions = { withValue: ['f'] };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: {}, values: {}, positionals: ['-afb'] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('handles short-option groups in conjunction with long-options', function(t) {
+  const passedArgs = ['-rf', '--foo', 'foo'];
+  const passedOptions = { withValue: ['foo'] };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: { r: true, f: true, foo: true }, values: { r: undefined, f: undefined, foo: 'foo' }, positionals: [] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('handles short-option groups with "short" alias configured', function(t) {
+  const passedArgs = ['-rf'];
+  const passedOptions = { short: { r: 'remove' } };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});

--- a/test/short-option-group.js
+++ b/test/short-option-group.js
@@ -49,6 +49,17 @@ test('when middle of short-option group expects value and strict:false then arg 
   t.end();
 });
 
+test('when middle of short-option group expects value via alias and strict:false then arg returned as positional (as not a valid group)', function(t) {
+  const passedArgs = ['-afb'];
+  const passedOptions = { short: { f: 'file' }, withValue: ['file'], strict: false };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: {}, values: {}, positionals: ['-afb'] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
 test('handles short-option groups in conjunction with long-options', function(t) {
   const passedArgs = ['-rf', '--foo', 'foo'];
   const passedOptions = { withValue: ['foo'] };

--- a/test/short-option-group.js
+++ b/test/short-option-group.js
@@ -38,9 +38,9 @@ test('when terminal of short-option group expects value then subsequent argument
   t.end();
 });
 
-test('when middle of short-option group expects value then arg returned as positional (as not a valid group)', function(t) {
+test('when middle of short-option group expects value and strict:false then arg returned as positional (as not a valid group)', function(t) {
   const passedArgs = ['-afb'];
-  const passedOptions = { withValue: ['f'] };
+  const passedOptions = { withValue: ['f'], strict: false };
 
   const args = parseArgs(passedArgs, passedOptions);
   const expected = { flags: {}, values: {}, positionals: ['-afb'] };

--- a/test/short-option-group.js
+++ b/test/short-option-group.js
@@ -70,3 +70,13 @@ test('handles short-option groups with "short" alias configured', function(t) {
 
   t.end();
 });
+
+test('when parse explicit args containing short group then callers args not modified', function(t) {
+  const passedArgs = ['-rf'];
+  const originalArgs = passedArgs.slice();
+
+  parseArgs(passedArgs);
+  t.deepEqual(passedArgs, originalArgs);
+
+  t.end();
+});

--- a/test/short-option-with-value.js
+++ b/test/short-option-with-value.js
@@ -1,0 +1,38 @@
+'use strict';
+/* eslint max-len: 0 */
+
+const test = require('tape');
+const { parseArgs } = require('../index.js');
+
+test('when combine short and value then result has option with value', function(t) {
+  const passedArgs = ['-fBAR'];
+  const passedOptions = { withValue: ['f'] };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: { f: true }, values: { f: 'BAR' }, positionals: [] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('when combine short and value followed by positional then result has positional', function(t) {
+  const passedArgs = ['-fBAR', 'positional'];
+  const passedOptions = { withValue: ['f'] };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: { f: true }, values: { f: 'BAR' }, positionals: ['positional'] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});
+
+test('when combine short with alias and value then result has long option with value', function(t) {
+  const passedArgs = ['-fBAR'];
+  const passedOptions = { short: { f: 'foo' }, withValue: ['foo'] };
+
+  const args = parseArgs(passedArgs, passedOptions);
+  const expected = { flags: { foo: true }, values: { foo: 'BAR' }, positionals: [] };
+  t.deepEqual(args, expected);
+
+  t.end();
+});


### PR DESCRIPTION
(This PR builds on #68 so the diff is currently noisy. To see the new code in the meantime look for `isShortAndValue`.)

Add support for combining an option and its value in the same argument. For example these are the same using the `tail` command:

```
tail -n 3 index.js 
tail -n3 index.js 
```

Or with `parseArgs`:
```js
parseArgs(['-n', '3'], { withValue: ['n'] });
parseArgs(['-n3'], { withValue: ['n'] });
```

NB: this is the classic pattern with value directly following short and _not_ the same pattern included in #62 which used `-n=3`. Which might prompt some discussion...

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
