### PR TITLE
refactor!: rework results to have parsedOptions property and store true in values for boolean options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ process.mainArgs = process.argv.slice(process._exec ? 1 : 2)
     * `short` {string} (Optional) A single character alias for an option; When appearing one or more times in `args`; Respects the `multiple` configuration
   * `strict` {Boolean} (Optional) A `Boolean` on wheather or not to throw an error when unknown args are encountered
 * Returns: {Object} An object having properties:
-  * `foundOptions` {Object}, key:true for each option found in the input `args`
+  * `parsedOptions` {Object}, key:true for each option found in the input `args`
   * `values` {Object}, key:value for each option found. Value is a string for string options, or `true` for boolean options, or an array for  options configured as `multiple:true`.
   * `positionals` {string[]}, containing [Positionals][]
 
@@ -103,8 +103,8 @@ const { parseArgs } = require('@pkgjs/parseargs');
 const { parseArgs } = require('@pkgjs/parseargs');
 const args = ['-f', '--foo=a', '--bar', 'b'];
 const options = {};
-const { foundOptions, values, positionals } = parseArgs({ args, options });
-// foundOptions = { f: true, foo: true, bar: true }
+const { parsedOptions, values, positionals } = parseArgs({ args, options });
+// parsedOptions = { f: true, foo: true, bar: true }
 // values = { f: true, foo: 'a', bar: true }
 // positionals = ['b']
 ```
@@ -118,8 +118,8 @@ const options = {
     type: 'string',
   },
 };
-const { foundOptions, values, positionals } = parseArgs({ args, options });
-// foundOptions = { f: true, foo: true, bar: true }
+const { parsedOptions, values, positionals } = parseArgs({ args, options });
+// parsedOptions = { f: true, foo: true, bar: true }
 // values = { f: true, foo: 'a', bar: 'b' }
 // positionals = []
 ```
@@ -134,8 +134,8 @@ const options = {
     multiple: true,
   },
 };
-const { foundOptions, values, positionals } = parseArgs({ args, options });
-// foundOptions = { f: true, foo: true }
+const { parsedOptions, values, positionals } = parseArgs({ args, options });
+// parsedOptions = { f: true, foo: true }
 // values = { f: true, foo: [ 'a', 'b' ] }
 // positionals = []
 ```
@@ -149,8 +149,8 @@ const options = {
     short: 'f',
   },
 };
-const { foundOptions, values, positionals } = parseArgs({ args, options });
-// foundOptions = { foo: true }
+const { parsedOptions, values, positionals } = parseArgs({ args, options });
+// parsedOptions = { foo: true }
 // values = { foo: true }
 // positionals = ['b']
 ```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ process.mainArgs = process.argv.slice(process._exec ? 1 : 2)
   * `strict` {Boolean} (Optional) A `Boolean` on wheather or not to throw an error when unknown args are encountered
 * Returns: {Object} An object having properties:
   * `foundOptions` {Object}, key:true for each option found in the input `args`
-  * `values` {Object}, key:value for each option found. Value is a string for string options, or `true` for boolean options, or an array for  options configured as "multiple".
+  * `values` {Object}, key:value for each option found. Value is a string for string options, or `true` for boolean options, or an array for  options configured as `multiple:true`.
   * `positionals` {string[]}, containing [Positionals][]
 
 ----

--- a/index.js
+++ b/index.js
@@ -73,19 +73,19 @@ function storeOptionValue(options, longOption, value, result) {
   result.foundOptions[longOption] = true;
 
   // Values
+  const usedAsFlag = value === undefined;
+  const newValue = usedAsFlag ? true : value;
   if (optionConfig.multiple) {
     // Always store value in array, including for flags.
     // result.values[longOption] starts out not present,
     // first value is added as new array [newValue],
     // subsequent values are pushed to existing array.
-    const usedAsFlag = value === undefined;
-    const newValue = usedAsFlag ? true : value;
     if (result.values[longOption] !== undefined)
       ArrayPrototypePush(result.values[longOption], newValue);
     else
       result.values[longOption] = [newValue];
   } else {
-    result.values[longOption] = value;
+    result.values[longOption] = newValue;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ function getMainArgs() {
 function storeOptionValue(options, longOption, value, result) {
   const optionConfig = options[longOption] || {};
 
-  // Flags
-  result.flags[longOption] = true;
+  // foundOptions
+  result.foundOptions[longOption] = true;
 
   // Values
   if (optionConfig.multiple) {
@@ -119,7 +119,7 @@ const parseArgs = ({
   );
 
   const result = {
-    flags: {},
+    foundOptions: {},
     values: {},
     positionals: []
   };

--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ function getMainArgs() {
 function storeOptionValue(options, longOption, value, result) {
   const optionConfig = options[longOption] || {};
 
-  // foundOptions
-  result.foundOptions[longOption] = true;
+  // parsedOptions
+  result.parsedOptions[longOption] = true;
 
   // Values
   const usedAsFlag = value === undefined;
@@ -119,7 +119,7 @@ const parseArgs = ({
   );
 
   const result = {
-    foundOptions: {},
+    parsedOptions: {},
     values: {},
     positionals: []
   };

--- a/test/dash.js
+++ b/test/dash.js
@@ -13,7 +13,7 @@ const { parseArgs } = require('../index.js');
 
 test("dash: when args include '-' used as positional then result has '-' in positionals", (t) => {
   const passedArgs = ['-'];
-  const expected = { flags: {}, values: {}, positionals: ['-'] };
+  const expected = { foundOptions: {}, values: {}, positionals: ['-'] };
 
   const result = parseArgs({ args: passedArgs });
 
@@ -25,7 +25,7 @@ test("dash: when args include '-' used as positional then result has '-' in posi
 test("dash: when args include '-' used as space-separated option value then result has '-' in option value", (t) => {
   const passedArgs = ['-v', '-'];
   const passedOptions = { v: { type: 'string' } };
-  const expected = { flags: { v: true }, values: { v: '-' }, positionals: [] };
+  const expected = { foundOptions: { v: true }, values: { v: '-' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 

--- a/test/dash.js
+++ b/test/dash.js
@@ -13,7 +13,7 @@ const { parseArgs } = require('../index.js');
 
 test("dash: when args include '-' used as positional then result has '-' in positionals", (t) => {
   const passedArgs = ['-'];
-  const expected = { foundOptions: {}, values: {}, positionals: ['-'] };
+  const expected = { parsedOptions: {}, values: {}, positionals: ['-'] };
 
   const result = parseArgs({ args: passedArgs });
 
@@ -25,7 +25,7 @@ test("dash: when args include '-' used as positional then result has '-' in posi
 test("dash: when args include '-' used as space-separated option value then result has '-' in option value", (t) => {
   const passedArgs = ['-v', '-'];
   const passedOptions = { v: { type: 'string' } };
-  const expected = { foundOptions: { v: true }, values: { v: '-' }, positionals: [] };
+  const expected = { parsedOptions: { v: true }, values: { v: '-' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 

--- a/test/examples.js
+++ b/test/examples.js
@@ -9,7 +9,7 @@ function show(args, options) {
   console.log('options = %O', options);
   console.log('---');
   const result = parseArgs({ args, options });
-  console.log('foundOptions = %O', result.foundOptions);
+  console.log('parsedOptions = %O', result.parsedOptions);
   console.log('values = %O', result.values);
   console.log('positionals = %O', result.positionals);
   console.log('-------------------------------------------\n');

--- a/test/examples.js
+++ b/test/examples.js
@@ -1,0 +1,48 @@
+'use strict';
+/* eslint max-len: 0 */
+const { parseArgs } = require('../index.js');
+
+// Examples from README for checking got them right!
+
+function show(args, options) {
+  console.log('args = %O', args);
+  console.log('options = %O', options);
+  console.log('---');
+  const result = parseArgs({ args, options });
+  console.log('foundOptions = %O', result.foundOptions);
+  console.log('values = %O', result.values);
+  console.log('positionals = %O', result.positionals);
+  console.log('-------------------------------------------\n');
+}
+
+let args;
+let options;
+
+args = ['-f', '--foo=a', '--bar', 'b'];
+options = {};
+show(args, options);
+
+args = ['-f', '--foo=a', '--bar', 'b'];
+options = {
+  bar: {
+    type: 'string',
+  },
+};
+show(args, options);
+
+args = ['-f', '--foo=a', '--foo', 'b'];
+options = {
+  foo: {
+    type: 'string',
+    multiple: true,
+  },
+};
+show(args, options);
+
+args = ['-f', 'b'];
+options = {
+  foo: {
+    short: 'f',
+  },
+};
+show(args, options);

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ const { parseArgs } = require('../index.js');
 
 test('when short option used as flag then stored as flag', function(t) {
   const passedArgs = ['-f'];
-  const expected = { foundOptions: { f: true }, values: { f: undefined }, positionals: [] };
+  const expected = { foundOptions: { f: true }, values: { f: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
@@ -18,7 +18,7 @@ test('when short option used as flag then stored as flag', function(t) {
 
 test('when short option used as flag before positional then stored as flag and positional (and not value)', function(t) {
   const passedArgs = ['-f', 'bar'];
-  const expected = { foundOptions: { f: true }, values: { f: undefined }, positionals: [ 'bar' ] };
+  const expected = { foundOptions: { f: true }, values: { f: true }, positionals: [ 'bar' ] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
@@ -40,7 +40,7 @@ test('when short option `type: "string"` used with value then stored as value', 
 test('when short option listed in short used as flag then long option stored as flag', function(t) {
   const passedArgs = ['-f'];
   const passedOptions = { foo: { short: 'f' } };
-  const expected = { foundOptions: { foo: true }, values: { foo: undefined }, positionals: [] };
+  const expected = { foundOptions: { foo: true }, values: { foo: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -62,7 +62,7 @@ test('when short option listed in short and long listed in `type: "string"` and 
 test('when short option `type: "string"` used without value then stored as flag', function(t) {
   const passedArgs = ['-f'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { foundOptions: { f: true }, values: { f: undefined }, positionals: [] };
+  const expected = { foundOptions: { f: true }, values: { f: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -73,7 +73,7 @@ test('when short option `type: "string"` used without value then stored as flag'
 test('short option group behaves like multiple short options', function(t) {
   const passedArgs = ['-rf'];
   const passedOptions = { };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: [] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -84,7 +84,7 @@ test('short option group behaves like multiple short options', function(t) {
 test('short option group does not consume subsequent positional', function(t) {
   const passedArgs = ['-rf', 'foo'];
   const passedOptions = { };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['foo'] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['foo'] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -95,7 +95,7 @@ test('short option group does not consume subsequent positional', function(t) {
 test('if terminal of short-option group configured `type: "string"`, subsequent positional is stored', function(t) {
   const passedArgs = ['-rvf', 'foo'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { foundOptions: { r: true, f: true, v: true }, values: { r: undefined, v: undefined, f: 'foo' }, positionals: [] };
+  const expected = { foundOptions: { r: true, f: true, v: true }, values: { r: true, v: true, f: 'foo' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -105,7 +105,7 @@ test('if terminal of short-option group configured `type: "string"`, subsequent 
 test('handles short-option groups in conjunction with long-options', function(t) {
   const passedArgs = ['-rf', '--foo', 'foo'];
   const passedOptions = { foo: { type: 'string' } };
-  const expected = { foundOptions: { r: true, f: true, foo: true }, values: { r: undefined, f: undefined, foo: 'foo' }, positionals: [] };
+  const expected = { foundOptions: { r: true, f: true, foo: true }, values: { r: true, f: true, foo: 'foo' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -115,7 +115,7 @@ test('handles short-option groups in conjunction with long-options', function(t)
 test('handles short-option groups with "short" alias configured', function(t) {
   const passedArgs = ['-rf'];
   const passedOptions = { remove: { short: 'r' } };
-  const expected = { foundOptions: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
+  const expected = { foundOptions: { remove: true, f: true }, values: { remove: true, f: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -134,7 +134,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 
 test('args are true', function(t) {
   const passedArgs = ['--foo', '--bar'];
-  const expected = { foundOptions: { foo: true, bar: true }, values: { foo: undefined, bar: undefined }, positionals: [] };
+  const expected = { foundOptions: { foo: true, bar: true }, values: { foo: true, bar: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'args are true');
@@ -144,7 +144,7 @@ test('args are true', function(t) {
 
 test('arg is true and positional is identified', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
-  const expected = { foundOptions: { foo: true }, values: { foo: undefined }, positionals: ['b'] };
+  const expected = { foundOptions: { foo: true }, values: { foo: true }, positionals: ['b'] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'arg is true and positional is identified');
@@ -253,7 +253,7 @@ test('correct default args when use node -p', function(t) {
   const result = parseArgs();
 
   const expected = { foundOptions: { foo: true },
-                     values: { foo: undefined },
+                     values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -270,7 +270,7 @@ test('correct default args when use node --print', function(t) {
   const result = parseArgs();
 
   const expected = { foundOptions: { foo: true },
-                     values: { foo: undefined },
+                     values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -287,7 +287,7 @@ test('correct default args when use node -e', function(t) {
   const result = parseArgs();
 
   const expected = { foundOptions: { foo: true },
-                     values: { foo: undefined },
+                     values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -304,7 +304,7 @@ test('correct default args when use node --eval', function(t) {
   const result = parseArgs();
 
   const expected = { foundOptions: { foo: true },
-                     values: { foo: undefined },
+                     values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -321,7 +321,7 @@ test('correct default args when normal arguments', function(t) {
   const result = parseArgs();
 
   const expected = { foundOptions: { foo: true },
-                     values: { foo: undefined },
+                     values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
 
@@ -336,7 +336,7 @@ test('excess leading dashes on options are retained', function(t) {
   const passedOptions = { };
   const expected = {
     foundOptions: { '-triple': true },
-    values: { '-triple': undefined },
+    values: { '-triple': true },
     positionals: []
   };
   const result = parseArgs({ args: passedArgs, options: passedOptions });

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ const { parseArgs } = require('../index.js');
 
 test('when short option used as flag then stored as flag', function(t) {
   const passedArgs = ['-f'];
-  const expected = { flags: { f: true }, values: { f: undefined }, positionals: [] };
+  const expected = { foundOptions: { f: true }, values: { f: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
@@ -18,7 +18,7 @@ test('when short option used as flag then stored as flag', function(t) {
 
 test('when short option used as flag before positional then stored as flag and positional (and not value)', function(t) {
   const passedArgs = ['-f', 'bar'];
-  const expected = { flags: { f: true }, values: { f: undefined }, positionals: [ 'bar' ] };
+  const expected = { foundOptions: { f: true }, values: { f: undefined }, positionals: [ 'bar' ] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
@@ -29,7 +29,7 @@ test('when short option used as flag before positional then stored as flag and p
 test('when short option `type: "string"` used with value then stored as value', function(t) {
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { flags: { f: true }, values: { f: 'bar' }, positionals: [] };
+  const expected = { foundOptions: { f: true }, values: { f: 'bar' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -40,7 +40,7 @@ test('when short option `type: "string"` used with value then stored as value', 
 test('when short option listed in short used as flag then long option stored as flag', function(t) {
   const passedArgs = ['-f'];
   const passedOptions = { foo: { short: 'f' } };
-  const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: [] };
+  const expected = { foundOptions: { foo: true }, values: { foo: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -51,7 +51,7 @@ test('when short option listed in short used as flag then long option stored as 
 test('when short option listed in short and long listed in `type: "string"` and used with value then long option stored as value', function(t) {
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { foo: { short: 'f', type: 'string' } };
-  const expected = { flags: { foo: true }, values: { foo: 'bar' }, positionals: [] };
+  const expected = { foundOptions: { foo: true }, values: { foo: 'bar' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -62,7 +62,7 @@ test('when short option listed in short and long listed in `type: "string"` and 
 test('when short option `type: "string"` used without value then stored as flag', function(t) {
   const passedArgs = ['-f'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { flags: { f: true }, values: { f: undefined }, positionals: [] };
+  const expected = { foundOptions: { f: true }, values: { f: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -73,7 +73,7 @@ test('when short option `type: "string"` used without value then stored as flag'
 test('short option group behaves like multiple short options', function(t) {
   const passedArgs = ['-rf'];
   const passedOptions = { };
-  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: [] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -84,7 +84,7 @@ test('short option group behaves like multiple short options', function(t) {
 test('short option group does not consume subsequent positional', function(t) {
   const passedArgs = ['-rf', 'foo'];
   const passedOptions = { };
-  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['foo'] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['foo'] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -95,7 +95,7 @@ test('short option group does not consume subsequent positional', function(t) {
 test('if terminal of short-option group configured `type: "string"`, subsequent positional is stored', function(t) {
   const passedArgs = ['-rvf', 'foo'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { flags: { r: true, f: true, v: true }, values: { r: undefined, v: undefined, f: 'foo' }, positionals: [] };
+  const expected = { foundOptions: { r: true, f: true, v: true }, values: { r: undefined, v: undefined, f: 'foo' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -105,7 +105,7 @@ test('if terminal of short-option group configured `type: "string"`, subsequent 
 test('handles short-option groups in conjunction with long-options', function(t) {
   const passedArgs = ['-rf', '--foo', 'foo'];
   const passedOptions = { foo: { type: 'string' } };
-  const expected = { flags: { r: true, f: true, foo: true }, values: { r: undefined, f: undefined, foo: 'foo' }, positionals: [] };
+  const expected = { foundOptions: { r: true, f: true, foo: true }, values: { r: undefined, f: undefined, foo: 'foo' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -115,7 +115,7 @@ test('handles short-option groups in conjunction with long-options', function(t)
 test('handles short-option groups with "short" alias configured', function(t) {
   const passedArgs = ['-rf'];
   const passedOptions = { remove: { short: 'r' } };
-  const expected = { flags: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
+  const expected = { foundOptions: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -124,7 +124,7 @@ test('handles short-option groups with "short" alias configured', function(t) {
 
 test('Everything after a bare `--` is considered a positional argument', function(t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals'];
-  const expected = { flags: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };
+  const expected = { foundOptions: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'testing bare positionals');
@@ -134,7 +134,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 
 test('args are true', function(t) {
   const passedArgs = ['--foo', '--bar'];
-  const expected = { flags: { foo: true, bar: true }, values: { foo: undefined, bar: undefined }, positionals: [] };
+  const expected = { foundOptions: { foo: true, bar: true }, values: { foo: undefined, bar: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'args are true');
@@ -144,7 +144,7 @@ test('args are true', function(t) {
 
 test('arg is true and positional is identified', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
-  const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: ['b'] };
+  const expected = { foundOptions: { foo: true }, values: { foo: undefined }, positionals: ['b'] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'arg is true and positional is identified');
@@ -155,7 +155,7 @@ test('arg is true and positional is identified', function(t) {
 test('args equals are passed `type: "string"`', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { so: { type: 'string' } };
-  const expected = { flags: { so: true }, values: { so: 'wat' }, positionals: [] };
+  const expected = { foundOptions: { so: true }, values: { so: 'wat' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
@@ -165,7 +165,7 @@ test('args equals are passed `type: "string"`', function(t) {
 
 test('when args include single dash then result stores dash as positional', function(t) {
   const passedArgs = ['-'];
-  const expected = { flags: { }, values: { }, positionals: ['-'] };
+  const expected = { foundOptions: { }, values: { }, positionals: ['-'] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
@@ -176,7 +176,7 @@ test('when args include single dash then result stores dash as positional', func
 test('zero config args equals are parsed as if `type: "string"`', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { };
-  const expected = { flags: { so: true }, values: { so: 'wat' }, positionals: [] };
+  const expected = { foundOptions: { so: true }, values: { so: 'wat' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
@@ -187,7 +187,7 @@ test('zero config args equals are parsed as if `type: "string"`', function(t) {
 test('same arg is passed twice `type: "string"` and last value is recorded', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = { foo: { type: 'string' } };
-  const expected = { flags: { foo: true }, values: { foo: 'b' }, positionals: [] };
+  const expected = { foundOptions: { foo: true }, values: { foo: 'b' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'last arg value is passed');
@@ -198,7 +198,7 @@ test('same arg is passed twice `type: "string"` and last value is recorded', fun
 test('args equals pass string including more equals', function(t) {
   const passedArgs = ['--so=wat=bing'];
   const passedOptions = { so: { type: 'string' } };
-  const expected = { flags: { so: true }, values: { so: 'wat=bing' }, positionals: [] };
+  const expected = { foundOptions: { so: true }, values: { so: 'wat=bing' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
@@ -209,7 +209,7 @@ test('args equals pass string including more equals', function(t) {
 test('first arg passed for `type: "string"` and "multiple" is in array', function(t) {
   const passedArgs = ['--foo=a'];
   const passedOptions = { foo: { type: 'string', multiple: true } };
-  const expected = { flags: { foo: true }, values: { foo: ['a'] }, positionals: [] };
+  const expected = { foundOptions: { foo: true }, values: { foo: ['a'] }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'first multiple in array');
@@ -225,7 +225,7 @@ test('args are passed `type: "string"` and "multiple"', function(t) {
       multiple: true,
     },
   };
-  const expected = { flags: { foo: true }, values: { foo: ['a', 'b'] }, positionals: [] };
+  const expected = { foundOptions: { foo: true }, values: { foo: ['a', 'b'] }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'both arg values are passed');
@@ -237,7 +237,7 @@ test('order of option and positional does not matter (per README)', function(t) 
   const passedArgs1 = ['--foo=bar', 'baz'];
   const passedArgs2 = ['baz', '--foo=bar'];
   const passedOptions = { foo: { type: 'string' } };
-  const expected = { flags: { foo: true }, values: { foo: 'bar' }, positionals: ['baz'] };
+  const expected = { foundOptions: { foo: true }, values: { foo: 'bar' }, positionals: ['baz'] };
 
   t.deepEqual(parseArgs({ args: passedArgs1, options: passedOptions }), expected, 'option then positional');
   t.deepEqual(parseArgs({ args: passedArgs2, options: passedOptions }), expected, 'positional then option');
@@ -252,7 +252,7 @@ test('correct default args when use node -p', function(t) {
   process.execArgv = ['-p', '0'];
   const result = parseArgs();
 
-  const expected = { flags: { foo: true },
+  const expected = { foundOptions: { foo: true },
                      values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -269,7 +269,7 @@ test('correct default args when use node --print', function(t) {
   process.execArgv = ['--print', '0'];
   const result = parseArgs();
 
-  const expected = { flags: { foo: true },
+  const expected = { foundOptions: { foo: true },
                      values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -286,7 +286,7 @@ test('correct default args when use node -e', function(t) {
   process.execArgv = ['-e', '0'];
   const result = parseArgs();
 
-  const expected = { flags: { foo: true },
+  const expected = { foundOptions: { foo: true },
                      values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -303,7 +303,7 @@ test('correct default args when use node --eval', function(t) {
   process.execArgv = ['--eval', '0'];
   const result = parseArgs();
 
-  const expected = { flags: { foo: true },
+  const expected = { foundOptions: { foo: true },
                      values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -320,7 +320,7 @@ test('correct default args when normal arguments', function(t) {
   process.execArgv = [];
   const result = parseArgs();
 
-  const expected = { flags: { foo: true },
+  const expected = { foundOptions: { foo: true },
                      values: { foo: undefined },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -335,7 +335,7 @@ test('excess leading dashes on options are retained', function(t) {
   const passedArgs = ['---triple'];
   const passedOptions = { };
   const expected = {
-    flags: { '-triple': true },
+    foundOptions: { '-triple': true },
     values: { '-triple': undefined },
     positionals: []
   };

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ const { parseArgs } = require('../index.js');
 
 test('when short option used as flag then stored as flag', function(t) {
   const passedArgs = ['-f'];
-  const expected = { foundOptions: { f: true }, values: { f: true }, positionals: [] };
+  const expected = { parsedOptions: { f: true }, values: { f: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
@@ -18,7 +18,7 @@ test('when short option used as flag then stored as flag', function(t) {
 
 test('when short option used as flag before positional then stored as flag and positional (and not value)', function(t) {
   const passedArgs = ['-f', 'bar'];
-  const expected = { foundOptions: { f: true }, values: { f: true }, positionals: [ 'bar' ] };
+  const expected = { parsedOptions: { f: true }, values: { f: true }, positionals: [ 'bar' ] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
@@ -29,7 +29,7 @@ test('when short option used as flag before positional then stored as flag and p
 test('when short option `type: "string"` used with value then stored as value', function(t) {
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { foundOptions: { f: true }, values: { f: 'bar' }, positionals: [] };
+  const expected = { parsedOptions: { f: true }, values: { f: 'bar' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -40,7 +40,7 @@ test('when short option `type: "string"` used with value then stored as value', 
 test('when short option listed in short used as flag then long option stored as flag', function(t) {
   const passedArgs = ['-f'];
   const passedOptions = { foo: { short: 'f' } };
-  const expected = { foundOptions: { foo: true }, values: { foo: true }, positionals: [] };
+  const expected = { parsedOptions: { foo: true }, values: { foo: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -51,7 +51,7 @@ test('when short option listed in short used as flag then long option stored as 
 test('when short option listed in short and long listed in `type: "string"` and used with value then long option stored as value', function(t) {
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { foo: { short: 'f', type: 'string' } };
-  const expected = { foundOptions: { foo: true }, values: { foo: 'bar' }, positionals: [] };
+  const expected = { parsedOptions: { foo: true }, values: { foo: 'bar' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -62,7 +62,7 @@ test('when short option listed in short and long listed in `type: "string"` and 
 test('when short option `type: "string"` used without value then stored as flag', function(t) {
   const passedArgs = ['-f'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { foundOptions: { f: true }, values: { f: true }, positionals: [] };
+  const expected = { parsedOptions: { f: true }, values: { f: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -73,7 +73,7 @@ test('when short option `type: "string"` used without value then stored as flag'
 test('short option group behaves like multiple short options', function(t) {
   const passedArgs = ['-rf'];
   const passedOptions = { };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: [] };
+  const expected = { parsedOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
@@ -84,7 +84,7 @@ test('short option group behaves like multiple short options', function(t) {
 test('short option group does not consume subsequent positional', function(t) {
   const passedArgs = ['-rf', 'foo'];
   const passedOptions = { };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['foo'] };
+  const expected = { parsedOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['foo'] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -95,7 +95,7 @@ test('short option group does not consume subsequent positional', function(t) {
 test('if terminal of short-option group configured `type: "string"`, subsequent positional is stored', function(t) {
   const passedArgs = ['-rvf', 'foo'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { foundOptions: { r: true, f: true, v: true }, values: { r: true, v: true, f: 'foo' }, positionals: [] };
+  const expected = { parsedOptions: { r: true, f: true, v: true }, values: { r: true, v: true, f: 'foo' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -105,7 +105,7 @@ test('if terminal of short-option group configured `type: "string"`, subsequent 
 test('handles short-option groups in conjunction with long-options', function(t) {
   const passedArgs = ['-rf', '--foo', 'foo'];
   const passedOptions = { foo: { type: 'string' } };
-  const expected = { foundOptions: { r: true, f: true, foo: true }, values: { r: true, f: true, foo: 'foo' }, positionals: [] };
+  const expected = { parsedOptions: { r: true, f: true, foo: true }, values: { r: true, f: true, foo: 'foo' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -115,7 +115,7 @@ test('handles short-option groups in conjunction with long-options', function(t)
 test('handles short-option groups with "short" alias configured', function(t) {
   const passedArgs = ['-rf'];
   const passedOptions = { remove: { short: 'r' } };
-  const expected = { foundOptions: { remove: true, f: true }, values: { remove: true, f: true }, positionals: [] };
+  const expected = { parsedOptions: { remove: true, f: true }, values: { remove: true, f: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
@@ -124,7 +124,7 @@ test('handles short-option groups with "short" alias configured', function(t) {
 
 test('Everything after a bare `--` is considered a positional argument', function(t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals'];
-  const expected = { foundOptions: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };
+  const expected = { parsedOptions: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'testing bare positionals');
@@ -134,7 +134,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 
 test('args are true', function(t) {
   const passedArgs = ['--foo', '--bar'];
-  const expected = { foundOptions: { foo: true, bar: true }, values: { foo: true, bar: true }, positionals: [] };
+  const expected = { parsedOptions: { foo: true, bar: true }, values: { foo: true, bar: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'args are true');
@@ -144,7 +144,7 @@ test('args are true', function(t) {
 
 test('arg is true and positional is identified', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
-  const expected = { foundOptions: { foo: true }, values: { foo: true }, positionals: ['b'] };
+  const expected = { parsedOptions: { foo: true }, values: { foo: true }, positionals: ['b'] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'arg is true and positional is identified');
@@ -155,7 +155,7 @@ test('arg is true and positional is identified', function(t) {
 test('args equals are passed `type: "string"`', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { so: { type: 'string' } };
-  const expected = { foundOptions: { so: true }, values: { so: 'wat' }, positionals: [] };
+  const expected = { parsedOptions: { so: true }, values: { so: 'wat' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
@@ -165,7 +165,7 @@ test('args equals are passed `type: "string"`', function(t) {
 
 test('when args include single dash then result stores dash as positional', function(t) {
   const passedArgs = ['-'];
-  const expected = { foundOptions: { }, values: { }, positionals: ['-'] };
+  const expected = { parsedOptions: { }, values: { }, positionals: ['-'] };
   const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
@@ -176,7 +176,7 @@ test('when args include single dash then result stores dash as positional', func
 test('zero config args equals are parsed as if `type: "string"`', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { };
-  const expected = { foundOptions: { so: true }, values: { so: 'wat' }, positionals: [] };
+  const expected = { parsedOptions: { so: true }, values: { so: 'wat' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
@@ -187,7 +187,7 @@ test('zero config args equals are parsed as if `type: "string"`', function(t) {
 test('same arg is passed twice `type: "string"` and last value is recorded', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = { foo: { type: 'string' } };
-  const expected = { foundOptions: { foo: true }, values: { foo: 'b' }, positionals: [] };
+  const expected = { parsedOptions: { foo: true }, values: { foo: 'b' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'last arg value is passed');
@@ -198,7 +198,7 @@ test('same arg is passed twice `type: "string"` and last value is recorded', fun
 test('args equals pass string including more equals', function(t) {
   const passedArgs = ['--so=wat=bing'];
   const passedOptions = { so: { type: 'string' } };
-  const expected = { foundOptions: { so: true }, values: { so: 'wat=bing' }, positionals: [] };
+  const expected = { parsedOptions: { so: true }, values: { so: 'wat=bing' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
@@ -209,7 +209,7 @@ test('args equals pass string including more equals', function(t) {
 test('first arg passed for `type: "string"` and "multiple" is in array', function(t) {
   const passedArgs = ['--foo=a'];
   const passedOptions = { foo: { type: 'string', multiple: true } };
-  const expected = { foundOptions: { foo: true }, values: { foo: ['a'] }, positionals: [] };
+  const expected = { parsedOptions: { foo: true }, values: { foo: ['a'] }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'first multiple in array');
@@ -225,7 +225,7 @@ test('args are passed `type: "string"` and "multiple"', function(t) {
       multiple: true,
     },
   };
-  const expected = { foundOptions: { foo: true }, values: { foo: ['a', 'b'] }, positionals: [] };
+  const expected = { parsedOptions: { foo: true }, values: { foo: ['a', 'b'] }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'both arg values are passed');
@@ -237,7 +237,7 @@ test('order of option and positional does not matter (per README)', function(t) 
   const passedArgs1 = ['--foo=bar', 'baz'];
   const passedArgs2 = ['baz', '--foo=bar'];
   const passedOptions = { foo: { type: 'string' } };
-  const expected = { foundOptions: { foo: true }, values: { foo: 'bar' }, positionals: ['baz'] };
+  const expected = { parsedOptions: { foo: true }, values: { foo: 'bar' }, positionals: ['baz'] };
 
   t.deepEqual(parseArgs({ args: passedArgs1, options: passedOptions }), expected, 'option then positional');
   t.deepEqual(parseArgs({ args: passedArgs2, options: passedOptions }), expected, 'positional then option');
@@ -252,7 +252,7 @@ test('correct default args when use node -p', function(t) {
   process.execArgv = ['-p', '0'];
   const result = parseArgs();
 
-  const expected = { foundOptions: { foo: true },
+  const expected = { parsedOptions: { foo: true },
                      values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -269,7 +269,7 @@ test('correct default args when use node --print', function(t) {
   process.execArgv = ['--print', '0'];
   const result = parseArgs();
 
-  const expected = { foundOptions: { foo: true },
+  const expected = { parsedOptions: { foo: true },
                      values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -286,7 +286,7 @@ test('correct default args when use node -e', function(t) {
   process.execArgv = ['-e', '0'];
   const result = parseArgs();
 
-  const expected = { foundOptions: { foo: true },
+  const expected = { parsedOptions: { foo: true },
                      values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -303,7 +303,7 @@ test('correct default args when use node --eval', function(t) {
   process.execArgv = ['--eval', '0'];
   const result = parseArgs();
 
-  const expected = { foundOptions: { foo: true },
+  const expected = { parsedOptions: { foo: true },
                      values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -320,7 +320,7 @@ test('correct default args when normal arguments', function(t) {
   process.execArgv = [];
   const result = parseArgs();
 
-  const expected = { foundOptions: { foo: true },
+  const expected = { parsedOptions: { foo: true },
                      values: { foo: true },
                      positionals: [] };
   t.deepEqual(result, expected);
@@ -335,7 +335,7 @@ test('excess leading dashes on options are retained', function(t) {
   const passedArgs = ['---triple'];
   const passedOptions = { };
   const expected = {
-    foundOptions: { '-triple': true },
+    parsedOptions: { '-triple': true },
     values: { '-triple': true },
     positionals: []
   };

--- a/test/short-option-combined-with-value.js
+++ b/test/short-option-combined-with-value.js
@@ -7,7 +7,7 @@ const { parseArgs } = require('../index.js');
 test('when combine string short with plain text then parsed as value', (t) => {
   const passedArgs = ['-aHELLO'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { foundOptions: { alpha: true }, values: { alpha: 'HELLO' }, positionals: [] };
+  const expected = { parsedOptions: { alpha: true }, values: { alpha: 'HELLO' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -18,7 +18,7 @@ test('when combine string short with plain text then parsed as value', (t) => {
 test('when combine low-config string short with plain text then parsed as value', (t) => {
   const passedArgs = ['-aHELLO'];
   const passedOptions = { a: { type: 'string' } };
-  const expected = { foundOptions: { a: true }, values: { a: 'HELLO' }, positionals: [] };
+  const expected = { parsedOptions: { a: true }, values: { a: 'HELLO' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -29,7 +29,7 @@ test('when combine low-config string short with plain text then parsed as value'
 test('when combine string short with value like short option then parsed as value', (t) => {
   const passedArgs = ['-a-b'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { foundOptions: { alpha: true }, values: { alpha: '-b' }, positionals: [] };
+  const expected = { parsedOptions: { alpha: true }, values: { alpha: '-b' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -40,7 +40,7 @@ test('when combine string short with value like short option then parsed as valu
 test('when combine string short with value like long option then parsed as value', (t) => {
   const passedArgs = ['-a--bar'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { foundOptions: { alpha: true }, values: { alpha: '--bar' }, positionals: [] };
+  const expected = { parsedOptions: { alpha: true }, values: { alpha: '--bar' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -51,7 +51,7 @@ test('when combine string short with value like long option then parsed as value
 test('when combine string short with value like negative number then parsed as value', (t) => {
   const passedArgs = ['-a-5'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { foundOptions: { alpha: true }, values: { alpha: '-5' }, positionals: [] };
+  const expected = { parsedOptions: { alpha: true }, values: { alpha: '-5' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -63,7 +63,7 @@ test('when combine string short with value like negative number then parsed as v
 test('when combine string short with value which matches configured flag then parsed as value', (t) => {
   const passedArgs = ['-af'];
   const passedOptions = { alpha: { short: 'a', type: 'string' }, file: { short: 'f' } };
-  const expected = { foundOptions: { alpha: true }, values: { alpha: 'f' }, positionals: [] };
+  const expected = { parsedOptions: { alpha: true }, values: { alpha: 'f' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -74,7 +74,7 @@ test('when combine string short with value which matches configured flag then pa
 test('when combine string short with value including equals then parsed with equals in value', (t) => {
   const passedArgs = ['-a=5'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { foundOptions: { alpha: true }, values: { alpha: '=5' }, positionals: [] };
+  const expected = { parsedOptions: { alpha: true }, values: { alpha: '=5' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 

--- a/test/short-option-combined-with-value.js
+++ b/test/short-option-combined-with-value.js
@@ -7,7 +7,7 @@ const { parseArgs } = require('../index.js');
 test('when combine string short with plain text then parsed as value', (t) => {
   const passedArgs = ['-aHELLO'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { flags: { alpha: true }, values: { alpha: 'HELLO' }, positionals: [] };
+  const expected = { foundOptions: { alpha: true }, values: { alpha: 'HELLO' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -18,7 +18,7 @@ test('when combine string short with plain text then parsed as value', (t) => {
 test('when combine low-config string short with plain text then parsed as value', (t) => {
   const passedArgs = ['-aHELLO'];
   const passedOptions = { a: { type: 'string' } };
-  const expected = { flags: { a: true }, values: { a: 'HELLO' }, positionals: [] };
+  const expected = { foundOptions: { a: true }, values: { a: 'HELLO' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -29,7 +29,7 @@ test('when combine low-config string short with plain text then parsed as value'
 test('when combine string short with value like short option then parsed as value', (t) => {
   const passedArgs = ['-a-b'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { flags: { alpha: true }, values: { alpha: '-b' }, positionals: [] };
+  const expected = { foundOptions: { alpha: true }, values: { alpha: '-b' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -40,7 +40,7 @@ test('when combine string short with value like short option then parsed as valu
 test('when combine string short with value like long option then parsed as value', (t) => {
   const passedArgs = ['-a--bar'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { flags: { alpha: true }, values: { alpha: '--bar' }, positionals: [] };
+  const expected = { foundOptions: { alpha: true }, values: { alpha: '--bar' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -51,7 +51,7 @@ test('when combine string short with value like long option then parsed as value
 test('when combine string short with value like negative number then parsed as value', (t) => {
   const passedArgs = ['-a-5'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { flags: { alpha: true }, values: { alpha: '-5' }, positionals: [] };
+  const expected = { foundOptions: { alpha: true }, values: { alpha: '-5' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -63,7 +63,7 @@ test('when combine string short with value like negative number then parsed as v
 test('when combine string short with value which matches configured flag then parsed as value', (t) => {
   const passedArgs = ['-af'];
   const passedOptions = { alpha: { short: 'a', type: 'string' }, file: { short: 'f' } };
-  const expected = { flags: { alpha: true }, values: { alpha: 'f' }, positionals: [] };
+  const expected = { foundOptions: { alpha: true }, values: { alpha: 'f' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -74,7 +74,7 @@ test('when combine string short with value which matches configured flag then pa
 test('when combine string short with value including equals then parsed with equals in value', (t) => {
   const passedArgs = ['-a=5'];
   const passedOptions = { alpha: { short: 'a', type: 'string' } };
-  const expected = { flags: { alpha: true }, values: { alpha: '=5' }, positionals: [] };
+  const expected = { foundOptions: { alpha: true }, values: { alpha: '=5' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 

--- a/test/short-option-groups.js
+++ b/test/short-option-groups.js
@@ -7,7 +7,7 @@ const { parseArgs } = require('../index.js');
 test('when pass zero-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
+  const expected = { parsedOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -18,7 +18,7 @@ test('when pass zero-config group of booleans then parsed as booleans', (t) => {
 test('when pass low-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: {}, f: {} };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
+  const expected = { parsedOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -29,7 +29,7 @@ test('when pass low-config group of booleans then parsed as booleans', (t) => {
 test('when pass full-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: { type: 'boolean' }, f: { type: 'boolean' } };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
+  const expected = { parsedOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -40,7 +40,7 @@ test('when pass full-config group of booleans then parsed as booleans', (t) => {
 test('when pass group with string option on end then parsed as booleans and string option', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: { type: 'boolean' }, f: { type: 'string' } };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: 'p' }, positionals: [] };
+  const expected = { parsedOptions: { r: true, f: true }, values: { r: true, f: 'p' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -51,7 +51,7 @@ test('when pass group with string option on end then parsed as booleans and stri
 test('when pass group with string option in middle and strict:false then parsed as booleans and string option with trailing value', (t) => {
   const passedArgs = ['-afb', 'p'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { foundOptions: { a: true, f: true }, values: { a: true, f: 'b' }, positionals: ['p'] };
+  const expected = { parsedOptions: { a: true, f: true }, values: { a: true, f: 'b' }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions, strict: false });
 

--- a/test/short-option-groups.js
+++ b/test/short-option-groups.js
@@ -7,7 +7,7 @@ const { parseArgs } = require('../index.js');
 test('when pass zero-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { };
-  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -18,7 +18,7 @@ test('when pass zero-config group of booleans then parsed as booleans', (t) => {
 test('when pass low-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: {}, f: {} };
-  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -29,7 +29,7 @@ test('when pass low-config group of booleans then parsed as booleans', (t) => {
 test('when pass full-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: { type: 'boolean' }, f: { type: 'boolean' } };
-  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -40,7 +40,7 @@ test('when pass full-config group of booleans then parsed as booleans', (t) => {
 test('when pass group with string option on end then parsed as booleans and string option', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: { type: 'boolean' }, f: { type: 'string' } };
-  const expected = { flags: { r: true, f: true }, values: { r: undefined, f: 'p' }, positionals: [] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: 'p' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -51,7 +51,7 @@ test('when pass group with string option on end then parsed as booleans and stri
 test('when pass group with string option in middle and strict:false then parsed as booleans and string option with trailing value', (t) => {
   const passedArgs = ['-afb', 'p'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { flags: { a: true, f: true }, values: { a: undefined, f: 'b' }, positionals: ['p'] };
+  const expected = { foundOptions: { a: true, f: true }, values: { a: undefined, f: 'b' }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions, strict: false });
 

--- a/test/short-option-groups.js
+++ b/test/short-option-groups.js
@@ -7,7 +7,7 @@ const { parseArgs } = require('../index.js');
 test('when pass zero-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -18,7 +18,7 @@ test('when pass zero-config group of booleans then parsed as booleans', (t) => {
 test('when pass low-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: {}, f: {} };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -29,7 +29,7 @@ test('when pass low-config group of booleans then parsed as booleans', (t) => {
 test('when pass full-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: { type: 'boolean' }, f: { type: 'boolean' } };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: true }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -40,7 +40,7 @@ test('when pass full-config group of booleans then parsed as booleans', (t) => {
 test('when pass group with string option on end then parsed as booleans and string option', (t) => {
   const passedArgs = ['-rf', 'p'];
   const passedOptions = { r: { type: 'boolean' }, f: { type: 'string' } };
-  const expected = { foundOptions: { r: true, f: true }, values: { r: undefined, f: 'p' }, positionals: [] };
+  const expected = { foundOptions: { r: true, f: true }, values: { r: true, f: 'p' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -51,7 +51,7 @@ test('when pass group with string option on end then parsed as booleans and stri
 test('when pass group with string option in middle and strict:false then parsed as booleans and string option with trailing value', (t) => {
   const passedArgs = ['-afb', 'p'];
   const passedOptions = { f: { type: 'string' } };
-  const expected = { foundOptions: { a: true, f: true }, values: { a: undefined, f: 'b' }, positionals: ['p'] };
+  const expected = { foundOptions: { a: true, f: true }, values: { a: true, f: 'b' }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions, strict: false });
 


### PR DESCRIPTION
See #70 for longer description.

In parse results, minor code changes:
- rename `flags` to `parsedOptions`
- store `true` in `values` for boolean options (rather than `undefined`)

In README, more churn:
- as above
- update result property descriptions
- show all options found in args in `parsedOptions`, not just boolean options
- update `--` description to match current implementation
- fix one example that got broken in a previous refactor
- replace "withValue" with "type:string"
- replace "flag" with "option" or " boolean option" as appropriate
- other small tweaks to wording

Added the examples in the README to a file so can confirm actual behaviour!

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
