### PR TITLE
disallow specifying multiple:true for boolean arguments

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -14,9 +14,16 @@ class ERR_INVALID_SHORT_OPTION extends TypeError {
   }
 }
 
+class ERR_MULTIPLE_FLAG extends TypeError {
+  constructor(longOption) {
+    super(`options.${longOption}.multiple cannot be used with \`type: 'boolean'\``);
+    this.code = 'ERR_MULTIPLE_FLAG';
+  }
+}
 module.exports = {
   codes: {
     ERR_INVALID_ARG_TYPE,
-    ERR_INVALID_SHORT_OPTION
+    ERR_INVALID_SHORT_OPTION,
+    ERR_MULTIPLE_FLAG
   }
 };

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const {
 const {
   codes: {
     ERR_INVALID_SHORT_OPTION,
+    ERR_MULTIPLE_FLAG,
   },
 } = require('./errors');
 
@@ -111,7 +112,8 @@ const parseArgs = ({
     ({ 0: longOption, 1: optionConfig }) => {
       validateObject(optionConfig, `options.${longOption}`);
 
-      if (ObjectHasOwn(optionConfig, 'type')) {
+      const hasType = ObjectHasOwn(optionConfig, 'type');
+      if (hasType) {
         validateUnion(optionConfig.type, `options.${longOption}.type`, ['string', 'boolean']);
       }
 
@@ -125,6 +127,11 @@ const parseArgs = ({
 
       if (ObjectHasOwn(optionConfig, 'multiple')) {
         validateBoolean(optionConfig.multiple, `options.${longOption}.multiple`);
+        if (optionConfig.multiple &&
+          hasType &&
+          optionConfig.type === 'boolean') {
+          throw new ERR_MULTIPLE_FLAG(longOption);
+        }
       }
     }
   );

--- a/test/index.js
+++ b/test/index.js
@@ -391,3 +391,14 @@ test('invalid short option length', function(t) {
 
   t.end();
 });
+
+test('`type: boolean` used with `multiple: true`', function(t) {
+  const passedArgs = [];
+  const passedOptions = { foo: { type: 'boolean', multiple: true } };
+
+  t.throws(function() { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+    code: 'ERR_MULTIPLE_FLAG'
+  });
+
+  t.end();
+});


### PR DESCRIPTION
`multiple` allows you to collect all the values for string arguments into an array. It doesn't do anything for boolean arguments. Best disallow it, I would think?