### PR TITLE
feat!: Require type to be specified for each supplied option

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ const args = ['-f', 'b'];
 const options = {
   foo: {
     short: 'f',
+    type: 'boolean'
   },
 };
 const { flags, values, positionals } = parseArgs({ args, options });

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ process.mainArgs = process.argv.slice(process._exec ? 1 : 2)
   * `args` {string[]} (Optional) Array of argument strings; defaults
     to [`process.mainArgs`](process_argv)
   * `options` {Object} (Optional) An object describing the known options to look for in `args`; `options` keys are the long names of the known options, and the values are objects with the following properties:
-    * `type` {'string'|'boolean'} (Optional) Type of known option; defaults to `'boolean'`; 
+    * `type` {'string'|'boolean'} (Required) Type of known option
     * `multiple` {boolean} (Optional) If true, when appearing one or more times in `args`, results are collected in an `Array`
     * `short` {string} (Optional) A single character alias for an option; When appearing one or more times in `args`; Respects the `multiple` configuration
   * `strict` {Boolean} (Optional) A `Boolean` on wheather or not to throw an error when unknown args are encountered

--- a/index.js
+++ b/index.js
@@ -111,9 +111,7 @@ const parseArgs = ({
     ({ 0: longOption, 1: optionConfig }) => {
       validateObject(optionConfig, `options.${longOption}`);
 
-      if (ObjectHasOwn(optionConfig, 'type')) {
-        validateUnion(optionConfig.type, `options.${longOption}.type`, ['string', 'boolean']);
-      }
+      validateUnion(optionConfig.type, `options.${longOption}.type`, ['string', 'boolean']);
 
       if (ObjectHasOwn(optionConfig, 'short')) {
         const shortOption = optionConfig.short;

--- a/test/index.js
+++ b/test/index.js
@@ -39,7 +39,7 @@ test('when short option `type: "string"` used with value then stored as value', 
 
 test('when short option listed in short used as flag then long option stored as flag', function(t) {
   const passedArgs = ['-f'];
-  const passedOptions = { foo: { short: 'f' } };
+  const passedOptions = { foo: { short: 'f', type: 'boolean' } };
   const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
 
@@ -114,7 +114,7 @@ test('handles short-option groups in conjunction with long-options', function(t)
 
 test('handles short-option groups with "short" alias configured', function(t) {
   const passedArgs = ['-rf'];
-  const passedOptions = { remove: { short: 'r' } };
+  const passedOptions = { remove: { short: 'r', type: 'boolean' } };
   const expected = { flags: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
@@ -359,6 +359,16 @@ test('invalid argument passed for options', function(t) {
   t.end();
 });
 
+test('then type property missing for option then throw', function(t) {
+  const knownOptions = { foo: { } };
+
+  t.throws(function() { parseArgs({ options: knownOptions }); }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+
+  t.end();
+});
+
 test('boolean passed to "type" option', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { foo: { type: true } };
@@ -383,7 +393,7 @@ test('invalid union value passed to "type" option', function(t) {
 
 test('invalid short option length', function(t) {
   const passedArgs = [];
-  const passedOptions = { foo: { short: 'fo' } };
+  const passedOptions = { foo: { short: 'fo', type: 'boolean' } };
 
   t.throws(function() { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_INVALID_SHORT_OPTION'

--- a/test/short-option-combined-with-value.js
+++ b/test/short-option-combined-with-value.js
@@ -62,7 +62,7 @@ test('when combine string short with value like negative number then parsed as v
 
 test('when combine string short with value which matches configured flag then parsed as value', (t) => {
   const passedArgs = ['-af'];
-  const passedOptions = { alpha: { short: 'a', type: 'string' }, file: { short: 'f' } };
+  const passedOptions = { alpha: { short: 'a', type: 'string' }, file: { short: 'f', type: 'boolean' } };
   const expected = { flags: { alpha: true }, values: { alpha: 'f' }, positionals: [] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });

--- a/test/short-option-groups.js
+++ b/test/short-option-groups.js
@@ -17,7 +17,7 @@ test('when pass zero-config group of booleans then parsed as booleans', (t) => {
 
 test('when pass low-config group of booleans then parsed as booleans', (t) => {
   const passedArgs = ['-rf', 'p'];
-  const passedOptions = { r: {}, f: {} };
+  const passedOptions = { r: { type: 'boolean' }, f: { type: 'boolean' } };
   const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['p'] };
 
   const result = parseArgs({ args: passedArgs, options: passedOptions });


### PR DESCRIPTION
Currently the type property is optional and defaults to boolean, but this is a bit opaque.

Closes: #94

Make it an error to leave out the type:
```js
parseArgs({
  options: {
    foo: { },
  },
});
```

```
ERR_INVALID_ARG_TYPE [TypeError]: options.foo.type must be ('string|boolean') got undefined
```

Correct:
```js
parseArgs({
  options: {
    foo: { type: 'boolean' },
  },
});
```

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
