### PR TITLE
refactor: use arrow functions for tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ const { parseArgs } = require('../index.js');
 
 // Test results are as we expect
 
-test('when short option used as flag then stored as flag', function(t) {
+test('when short option used as flag then stored as flag', (t) => {
   const passedArgs = ['-f'];
   const expected = { flags: { f: true }, values: { f: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs });
@@ -16,7 +16,7 @@ test('when short option used as flag then stored as flag', function(t) {
   t.end();
 });
 
-test('when short option used as flag before positional then stored as flag and positional (and not value)', function(t) {
+test('when short option used as flag before positional then stored as flag and positional (and not value)', (t) => {
   const passedArgs = ['-f', 'bar'];
   const expected = { flags: { f: true }, values: { f: undefined }, positionals: [ 'bar' ] };
   const args = parseArgs({ args: passedArgs });
@@ -26,7 +26,7 @@ test('when short option used as flag before positional then stored as flag and p
   t.end();
 });
 
-test('when short option `type: "string"` used with value then stored as value', function(t) {
+test('when short option `type: "string"` used with value then stored as value', (t) => {
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { flags: { f: true }, values: { f: 'bar' }, positionals: [] };
@@ -37,7 +37,7 @@ test('when short option `type: "string"` used with value then stored as value', 
   t.end();
 });
 
-test('when short option listed in short used as flag then long option stored as flag', function(t) {
+test('when short option listed in short used as flag then long option stored as flag', (t) => {
   const passedArgs = ['-f'];
   const passedOptions = { foo: { short: 'f' } };
   const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: [] };
@@ -48,7 +48,7 @@ test('when short option listed in short used as flag then long option stored as 
   t.end();
 });
 
-test('when short option listed in short and long listed in `type: "string"` and used with value then long option stored as value', function(t) {
+test('when short option listed in short and long listed in `type: "string"` and used with value then long option stored as value', (t) => {
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { foo: { short: 'f', type: 'string' } };
   const expected = { flags: { foo: true }, values: { foo: 'bar' }, positionals: [] };
@@ -59,7 +59,7 @@ test('when short option listed in short and long listed in `type: "string"` and 
   t.end();
 });
 
-test('when short option `type: "string"` used without value then stored as flag', function(t) {
+test('when short option `type: "string"` used without value then stored as flag', (t) => {
   const passedArgs = ['-f'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { flags: { f: true }, values: { f: undefined }, positionals: [] };
@@ -70,7 +70,7 @@ test('when short option `type: "string"` used without value then stored as flag'
   t.end();
 });
 
-test('short option group behaves like multiple short options', function(t) {
+test('short option group behaves like multiple short options', (t) => {
   const passedArgs = ['-rf'];
   const passedOptions = { };
   const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: [] };
@@ -81,7 +81,7 @@ test('short option group behaves like multiple short options', function(t) {
   t.end();
 });
 
-test('short option group does not consume subsequent positional', function(t) {
+test('short option group does not consume subsequent positional', (t) => {
   const passedArgs = ['-rf', 'foo'];
   const passedOptions = { };
   const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['foo'] };
@@ -92,7 +92,7 @@ test('short option group does not consume subsequent positional', function(t) {
 });
 
 // // See: Guideline 5 https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
-test('if terminal of short-option group configured `type: "string"`, subsequent positional is stored', function(t) {
+test('if terminal of short-option group configured `type: "string"`, subsequent positional is stored', (t) => {
   const passedArgs = ['-rvf', 'foo'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { flags: { r: true, f: true, v: true }, values: { r: undefined, v: undefined, f: 'foo' }, positionals: [] };
@@ -102,7 +102,7 @@ test('if terminal of short-option group configured `type: "string"`, subsequent 
   t.end();
 });
 
-test('handles short-option groups in conjunction with long-options', function(t) {
+test('handles short-option groups in conjunction with long-options', (t) => {
   const passedArgs = ['-rf', '--foo', 'foo'];
   const passedOptions = { foo: { type: 'string' } };
   const expected = { flags: { r: true, f: true, foo: true }, values: { r: undefined, f: undefined, foo: 'foo' }, positionals: [] };
@@ -112,7 +112,7 @@ test('handles short-option groups in conjunction with long-options', function(t)
   t.end();
 });
 
-test('handles short-option groups with "short" alias configured', function(t) {
+test('handles short-option groups with "short" alias configured', (t) => {
   const passedArgs = ['-rf'];
   const passedOptions = { remove: { short: 'r' } };
   const expected = { flags: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
@@ -122,7 +122,7 @@ test('handles short-option groups with "short" alias configured', function(t) {
   t.end();
 });
 
-test('Everything after a bare `--` is considered a positional argument', function(t) {
+test('Everything after a bare `--` is considered a positional argument', (t) => {
   const passedArgs = ['--', 'barepositionals', 'mopositionals'];
   const expected = { flags: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };
   const args = parseArgs({ args: passedArgs });
@@ -132,7 +132,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
   t.end();
 });
 
-test('args are true', function(t) {
+test('args are true', (t) => {
   const passedArgs = ['--foo', '--bar'];
   const expected = { flags: { foo: true, bar: true }, values: { foo: undefined, bar: undefined }, positionals: [] };
   const args = parseArgs({ args: passedArgs });
@@ -142,7 +142,7 @@ test('args are true', function(t) {
   t.end();
 });
 
-test('arg is true and positional is identified', function(t) {
+test('arg is true and positional is identified', (t) => {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: ['b'] };
   const args = parseArgs({ args: passedArgs });
@@ -152,7 +152,7 @@ test('arg is true and positional is identified', function(t) {
   t.end();
 });
 
-test('args equals are passed `type: "string"`', function(t) {
+test('args equals are passed `type: "string"`', (t) => {
   const passedArgs = ['--so=wat'];
   const passedOptions = { so: { type: 'string' } };
   const expected = { flags: { so: true }, values: { so: 'wat' }, positionals: [] };
@@ -163,7 +163,7 @@ test('args equals are passed `type: "string"`', function(t) {
   t.end();
 });
 
-test('when args include single dash then result stores dash as positional', function(t) {
+test('when args include single dash then result stores dash as positional', (t) => {
   const passedArgs = ['-'];
   const expected = { flags: { }, values: { }, positionals: ['-'] };
   const args = parseArgs({ args: passedArgs });
@@ -173,7 +173,7 @@ test('when args include single dash then result stores dash as positional', func
   t.end();
 });
 
-test('zero config args equals are parsed as if `type: "string"`', function(t) {
+test('zero config args equals are parsed as if `type: "string"`', (t) => {
   const passedArgs = ['--so=wat'];
   const passedOptions = { };
   const expected = { flags: { so: true }, values: { so: 'wat' }, positionals: [] };
@@ -184,7 +184,7 @@ test('zero config args equals are parsed as if `type: "string"`', function(t) {
   t.end();
 });
 
-test('same arg is passed twice `type: "string"` and last value is recorded', function(t) {
+test('same arg is passed twice `type: "string"` and last value is recorded', (t) => {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = { foo: { type: 'string' } };
   const expected = { flags: { foo: true }, values: { foo: 'b' }, positionals: [] };
@@ -195,7 +195,7 @@ test('same arg is passed twice `type: "string"` and last value is recorded', fun
   t.end();
 });
 
-test('args equals pass string including more equals', function(t) {
+test('args equals pass string including more equals', (t) => {
   const passedArgs = ['--so=wat=bing'];
   const passedOptions = { so: { type: 'string' } };
   const expected = { flags: { so: true }, values: { so: 'wat=bing' }, positionals: [] };
@@ -206,7 +206,7 @@ test('args equals pass string including more equals', function(t) {
   t.end();
 });
 
-test('first arg passed for `type: "string"` and "multiple" is in array', function(t) {
+test('first arg passed for `type: "string"` and "multiple" is in array', (t) => {
   const passedArgs = ['--foo=a'];
   const passedOptions = { foo: { type: 'string', multiple: true } };
   const expected = { flags: { foo: true }, values: { foo: ['a'] }, positionals: [] };
@@ -217,7 +217,7 @@ test('first arg passed for `type: "string"` and "multiple" is in array', functio
   t.end();
 });
 
-test('args are passed `type: "string"` and "multiple"', function(t) {
+test('args are passed `type: "string"` and "multiple"', (t) => {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = {
     foo: {
@@ -233,7 +233,7 @@ test('args are passed `type: "string"` and "multiple"', function(t) {
   t.end();
 });
 
-test('order of option and positional does not matter (per README)', function(t) {
+test('order of option and positional does not matter (per README)', (t) => {
   const passedArgs1 = ['--foo=bar', 'baz'];
   const passedArgs2 = ['baz', '--foo=bar'];
   const passedOptions = { foo: { type: 'string' } };
@@ -245,7 +245,7 @@ test('order of option and positional does not matter (per README)', function(t) 
   t.end();
 });
 
-test('correct default args when use node -p', function(t) {
+test('correct default args when use node -p', (t) => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];
   const holdExecArgv = process.execArgv;
@@ -262,7 +262,7 @@ test('correct default args when use node -p', function(t) {
   process.execArgv = holdExecArgv;
 });
 
-test('correct default args when use node --print', function(t) {
+test('correct default args when use node --print', (t) => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];
   const holdExecArgv = process.execArgv;
@@ -279,7 +279,7 @@ test('correct default args when use node --print', function(t) {
   process.execArgv = holdExecArgv;
 });
 
-test('correct default args when use node -e', function(t) {
+test('correct default args when use node -e', (t) => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];
   const holdExecArgv = process.execArgv;
@@ -296,7 +296,7 @@ test('correct default args when use node -e', function(t) {
   process.execArgv = holdExecArgv;
 });
 
-test('correct default args when use node --eval', function(t) {
+test('correct default args when use node --eval', (t) => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];
   const holdExecArgv = process.execArgv;
@@ -313,7 +313,7 @@ test('correct default args when use node --eval', function(t) {
   process.execArgv = holdExecArgv;
 });
 
-test('correct default args when normal arguments', function(t) {
+test('correct default args when normal arguments', (t) => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, 'script.js', '--foo'];
   const holdExecArgv = process.execArgv;
@@ -330,7 +330,7 @@ test('correct default args when normal arguments', function(t) {
   process.execArgv = holdExecArgv;
 });
 
-test('excess leading dashes on options are retained', function(t) {
+test('excess leading dashes on options are retained', (t) => {
   // Enforce a design decision for an edge case.
   const passedArgs = ['---triple'];
   const passedOptions = { };
@@ -348,7 +348,7 @@ test('excess leading dashes on options are retained', function(t) {
 
 // Test bad inputs
 
-test('invalid argument passed for options', function(t) {
+test('invalid argument passed for options', (t) => {
   const passedArgs = ['--so=wat'];
   const passedOptions = 'bad value';
 
@@ -359,7 +359,7 @@ test('invalid argument passed for options', function(t) {
   t.end();
 });
 
-test('boolean passed to "type" option', function(t) {
+test('boolean passed to "type" option', (t) => {
   const passedArgs = ['--so=wat'];
   const passedOptions = { foo: { type: true } };
 
@@ -370,7 +370,7 @@ test('boolean passed to "type" option', function(t) {
   t.end();
 });
 
-test('invalid union value passed to "type" option', function(t) {
+test('invalid union value passed to "type" option', (t) => {
   const passedArgs = ['--so=wat'];
   const passedOptions = { foo: { type: 'str' } };
 
@@ -381,7 +381,7 @@ test('invalid union value passed to "type" option', function(t) {
   t.end();
 });
 
-test('invalid short option length', function(t) {
+test('invalid short option length', (t) => {
   const passedArgs = [];
   const passedOptions = { foo: { short: 'fo' } };
 


### PR DESCRIPTION
Use arrow functions for tests.

Inconsistency noted: https://github.com/nodejs/node/pull/42675#discussion_r846693999

(Pretty sure this was also noted in an older PR, but can't find the reference.)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
