### PR TITLE
test: refactor test/index.js to match Node

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,224 +1,169 @@
+/* global assert */
+/* eslint max-len: ["error", {"code": 120}], */
 'use strict';
-/* eslint max-len: 0 */
 
-const test = require('tape');
-const { parseArgs } = require('../index.js');
+const { test } = require('./utils');
+const { parseArgs } = require('../index');
 
 // Test results are as we expect
 
-test('when short option used as flag then stored as flag', (t) => {
+test('when short option used as flag then stored as flag', () => {
   const passedArgs = ['-f'];
   const expected = { values: { f: true }, positionals: [] };
   const args = parseArgs({ strict: false, args: passedArgs });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('when short option used as flag before positional then stored as flag and positional (and not value)', (t) => {
+test('when short option used as flag before positional then stored as flag and positional (and not value)', () => {
   const passedArgs = ['-f', 'bar'];
   const expected = { values: { f: true }, positionals: [ 'bar' ] };
   const args = parseArgs({ strict: false, args: passedArgs });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('when short option `type: "string"` used with value then stored as value', (t) => {
+test('when short option `type: "string"` used with value then stored as value', () => {
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { values: { f: 'bar' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('when short option listed in short used as flag then long option stored as flag', (t) => {
+test('when short option listed in short used as flag then long option stored as flag', () => {
   const passedArgs = ['-f'];
   const passedOptions = { foo: { short: 'f', type: 'boolean' } };
   const expected = { values: { foo: true }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
 test('when short option listed in short and long listed in `type: "string"` and ' +
-     'used with value then long option stored as value', (t) => {
+     'used with value then long option stored as value', () => {
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { foo: { short: 'f', type: 'string' } };
   const expected = { values: { foo: 'bar' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('when short option `type: "string"` used without value then stored as flag', (t) => {
+test('when short option `type: "string"` used without value then stored as flag', () => {
   const passedArgs = ['-f'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { values: { f: true }, positionals: [] };
   const args = parseArgs({ strict: false, args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('short option group behaves like multiple short options', (t) => {
+test('short option group behaves like multiple short options', () => {
   const passedArgs = ['-rf'];
   const passedOptions = { };
   const expected = { values: { r: true, f: true }, positionals: [] };
   const args = parseArgs({ strict: false, args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('short option group does not consume subsequent positional', (t) => {
+test('short option group does not consume subsequent positional', () => {
   const passedArgs = ['-rf', 'foo'];
   const passedOptions = { };
   const expected = { values: { r: true, f: true }, positionals: ['foo'] };
   const args = parseArgs({ strict: false, args: passedArgs, options: passedOptions });
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
 // See: Guideline 5 https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
-test('if terminal of short-option group configured `type: "string"`, subsequent positional is stored', (t) => {
+test('if terminal of short-option group configured `type: "string"`, subsequent positional is stored', () => {
   const passedArgs = ['-rvf', 'foo'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { values: { r: true, v: true, f: 'foo' }, positionals: [] };
   const args = parseArgs({ strict: false, args: passedArgs, options: passedOptions });
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('handles short-option groups in conjunction with long-options', (t) => {
+test('handles short-option groups in conjunction with long-options', () => {
   const passedArgs = ['-rf', '--foo', 'foo'];
   const passedOptions = { foo: { type: 'string' } };
   const expected = { values: { r: true, f: true, foo: 'foo' }, positionals: [] };
   const args = parseArgs({ strict: false, args: passedArgs, options: passedOptions });
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('handles short-option groups with "short" alias configured', (t) => {
+test('handles short-option groups with "short" alias configured', () => {
   const passedArgs = ['-rf'];
   const passedOptions = { remove: { short: 'r', type: 'boolean' } };
   const expected = { values: { remove: true, f: true }, positionals: [] };
   const args = parseArgs({ strict: false, args: passedArgs, options: passedOptions });
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('Everything after a bare `--` is considered a positional argument', (t) => {
+test('Everything after a bare `--` is considered a positional argument', () => {
   const passedArgs = ['--', 'barepositionals', 'mopositionals'];
   const expected = { values: {}, positionals: ['barepositionals', 'mopositionals'] };
   const args = parseArgs({ args: passedArgs });
-
-  t.deepEqual(args, expected, Error('testing bare positionals'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('testing bare positionals'));
 });
 
-test('args are true', (t) => {
+test('args are true', () => {
   const passedArgs = ['--foo', '--bar'];
   const expected = { values: { foo: true, bar: true }, positionals: [] };
   const args = parseArgs({ strict: false, args: passedArgs });
-
-  t.deepEqual(args, expected, Error('args are true'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('args are true'));
 });
 
-test('arg is true and positional is identified', (t) => {
+test('arg is true and positional is identified', () => {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const expected = { values: { foo: true }, positionals: ['b'] };
   const args = parseArgs({ strict: false, args: passedArgs });
-
-  t.deepEqual(args, expected, Error('arg is true and positional is identified'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('arg is true and positional is identified'));
 });
 
-test('args equals are passed `type: "string"`', (t) => {
+test('args equals are passed `type: "string"`', () => {
   const passedArgs = ['--so=wat'];
   const passedOptions = { so: { type: 'string' } };
   const expected = { values: { so: 'wat' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected, Error('arg value is passed'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('arg value is passed'));
 });
 
-test('when args include single dash then result stores dash as positional', (t) => {
+test('when args include single dash then result stores dash as positional', () => {
   const passedArgs = ['-'];
   const expected = { values: { }, positionals: ['-'] };
   const args = parseArgs({ args: passedArgs });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('zero config args equals are parsed as if `type: "string"`', (t) => {
+test('zero config args equals are parsed as if `type: "string"`', () => {
   const passedArgs = ['--so=wat'];
   const passedOptions = { };
   const expected = { values: { so: 'wat' }, positionals: [] };
   const args = parseArgs({ strict: false, args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected, Error('arg value is passed'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('arg value is passed'));
 });
 
-test('same arg is passed twice `type: "string"` and last value is recorded', (t) => {
+test('same arg is passed twice `type: "string"` and last value is recorded', () => {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = { foo: { type: 'string' } };
   const expected = { values: { foo: 'b' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected, Error('last arg value is passed'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('last arg value is passed'));
 });
 
-test('args equals pass string including more equals', (t) => {
+test('args equals pass string including more equals', () => {
   const passedArgs = ['--so=wat=bing'];
   const passedOptions = { so: { type: 'string' } };
   const expected = { values: { so: 'wat=bing' }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected, Error('arg value is passed'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('arg value is passed'));
 });
 
-test('first arg passed for `type: "string"` and "multiple" is in array', (t) => {
+test('first arg passed for `type: "string"` and "multiple" is in array', () => {
   const passedArgs = ['--foo=a'];
   const passedOptions = { foo: { type: 'string', multiple: true } };
   const expected = { values: { foo: ['a'] }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected, Error('first multiple in array'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('first multiple in array'));
 });
 
-test('args are passed `type: "string"` and "multiple"', (t) => {
+test('args are passed `type: "string"` and "multiple"', () => {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = {
     foo: {
@@ -228,13 +173,11 @@ test('args are passed `type: "string"` and "multiple"', (t) => {
   };
   const expected = { values: { foo: ['a', 'b'] }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected, Error('both arg values are passed'));
-
-  t.end();
+  assert.deepStrictEqual(args, expected, Error('both arg values are passed'));
 });
 
-test('when expecting `multiple:true` boolean option and option used multiple times then result includes array of booleans matching usage', (t) => {
+test('when expecting `multiple:true` boolean option and option used multiple times then result includes array of ' +
+     'booleans matching usage', () => {
   const passedArgs = ['--foo', '--foo'];
   const passedOptions = {
     foo: {
@@ -244,25 +187,27 @@ test('when expecting `multiple:true` boolean option and option used multiple tim
   };
   const expected = { values: { foo: [true, true] }, positionals: [] };
   const args = parseArgs({ args: passedArgs, options: passedOptions });
-
-  t.deepEqual(args, expected);
-
-  t.end();
+  assert.deepStrictEqual(args, expected);
 });
 
-test('order of option and positional does not matter (per README)', (t) => {
+test('order of option and positional does not matter (per README)', () => {
   const passedArgs1 = ['--foo=bar', 'baz'];
   const passedArgs2 = ['baz', '--foo=bar'];
   const passedOptions = { foo: { type: 'string' } };
   const expected = { values: { foo: 'bar' }, positionals: ['baz'] };
-
-  t.deepEqual(parseArgs({ args: passedArgs1, options: passedOptions }), expected, Error('option then positional'));
-  t.deepEqual(parseArgs({ args: passedArgs2, options: passedOptions }), expected, Error('positional then option'));
-
-  t.end();
+  assert.deepStrictEqual(
+    parseArgs({ args: passedArgs1, options: passedOptions }),
+    expected,
+    Error('option then positional')
+  );
+  assert.deepStrictEqual(
+    parseArgs({ args: passedArgs2, options: passedOptions }),
+    expected,
+    Error('positional then option')
+  );
 });
 
-test('correct default args when use node -p', (t) => {
+test('correct default args when use node -p', () => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];
   const holdExecArgv = process.execArgv;
@@ -271,14 +216,12 @@ test('correct default args when use node -p', (t) => {
 
   const expected = { values: { foo: true },
                      positionals: [] };
-  t.deepEqual(result, expected);
-
-  t.end();
+  assert.deepStrictEqual(result, expected);
   process.argv = holdArgv;
   process.execArgv = holdExecArgv;
 });
 
-test('correct default args when use node --print', (t) => {
+test('correct default args when use node --print', () => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];
   const holdExecArgv = process.execArgv;
@@ -287,14 +230,12 @@ test('correct default args when use node --print', (t) => {
 
   const expected = { values: { foo: true },
                      positionals: [] };
-  t.deepEqual(result, expected);
-
-  t.end();
+  assert.deepStrictEqual(result, expected);
   process.argv = holdArgv;
   process.execArgv = holdExecArgv;
 });
 
-test('correct default args when use node -e', (t) => {
+test('correct default args when use node -e', () => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];
   const holdExecArgv = process.execArgv;
@@ -303,30 +244,25 @@ test('correct default args when use node -e', (t) => {
 
   const expected = { values: { foo: true },
                      positionals: [] };
-  t.deepEqual(result, expected);
-
-  t.end();
+  assert.deepStrictEqual(result, expected);
   process.argv = holdArgv;
   process.execArgv = holdExecArgv;
 });
 
-test('correct default args when use node --eval', (t) => {
+test('correct default args when use node --eval', () => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, '--foo'];
   const holdExecArgv = process.execArgv;
   process.execArgv = ['--eval', '0'];
   const result = parseArgs({ strict: false });
-
   const expected = { values: { foo: true },
                      positionals: [] };
-  t.deepEqual(result, expected);
-
-  t.end();
+  assert.deepStrictEqual(result, expected);
   process.argv = holdArgv;
   process.execArgv = holdExecArgv;
 });
 
-test('correct default args when normal arguments', (t) => {
+test('correct default args when normal arguments', () => {
   const holdArgv = process.argv;
   process.argv = [process.argv0, 'script.js', '--foo'];
   const holdExecArgv = process.execArgv;
@@ -335,14 +271,12 @@ test('correct default args when normal arguments', (t) => {
 
   const expected = { values: { foo: true },
                      positionals: [] };
-  t.deepEqual(result, expected);
-
-  t.end();
+  assert.deepStrictEqual(result, expected);
   process.argv = holdArgv;
   process.execArgv = holdExecArgv;
 });
 
-test('excess leading dashes on options are retained', (t) => {
+test('excess leading dashes on options are retained', () => {
   // Enforce a design decision for an edge case.
   const passedArgs = ['---triple'];
   const passedOptions = { };
@@ -351,132 +285,96 @@ test('excess leading dashes on options are retained', (t) => {
     positionals: []
   };
   const result = parseArgs({ strict: false, args: passedArgs, options: passedOptions });
-
-  t.deepEqual(result, expected, Error('excess option dashes are retained'));
-
-  t.end();
+  assert.deepStrictEqual(result, expected, Error('excess option dashes are retained'));
 });
 
 // Test bad inputs
 
-test('invalid argument passed for options', (t) => {
+test('invalid argument passed for options', () => {
   const passedArgs = ['--so=wat'];
   const passedOptions = 'bad value';
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_INVALID_ARG_TYPE'
   });
-
-  t.end();
 });
 
-test('then type property missing for option then throw', (t) => {
+test('then type property missing for option then throw', () => {
   const knownOptions = { foo: { } };
-
-  t.throws(() => { parseArgs({ options: knownOptions }); }, {
+  assert.throws(() => { parseArgs({ options: knownOptions }); }, {
     code: 'ERR_INVALID_ARG_TYPE'
   });
-
-  t.end();
 });
 
-test('boolean passed to "type" option', (t) => {
+test('boolean passed to "type" option', () => {
   const passedArgs = ['--so=wat'];
   const passedOptions = { foo: { type: true } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_INVALID_ARG_TYPE'
   });
-
-  t.end();
 });
 
-test('invalid union value passed to "type" option', (t) => {
+test('invalid union value passed to "type" option', () => {
   const passedArgs = ['--so=wat'];
   const passedOptions = { foo: { type: 'str' } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_INVALID_ARG_TYPE'
   });
-
-  t.end();
 });
 
 // Test strict mode
 
-test('unknown long option --bar', (t) => {
+test('unknown long option --bar', () => {
   const passedArgs = ['--foo', '--bar'];
   const passedOptions = { foo: { type: 'boolean' } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
   });
-
-  t.end();
 });
 
-test('unknown short option -b', (t) => {
+test('unknown short option -b', () => {
   const passedArgs = ['--foo', '-b'];
   const passedOptions = { foo: { type: 'boolean' } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
   });
-
-  t.end();
 });
 
-test('unknown option -r in short option group -bar', (t) => {
+test('unknown option -r in short option group -bar', () => {
   const passedArgs = ['-bar'];
   const passedOptions = { b: { type: 'boolean' }, a: { type: 'boolean' } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
   });
-
-  t.end();
 });
 
-test('unknown option with explicit value', (t) => {
+test('unknown option with explicit value', () => {
   const passedArgs = ['--foo', '--bar=baz'];
   const passedOptions = { foo: { type: 'boolean' } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
   });
-
-  t.end();
 });
 
-test('string option used as boolean', (t) => {
+test('string option used as boolean', () => {
   const passedArgs = ['--foo'];
   const passedOptions = { foo: { type: 'string' } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
   });
-
-  t.end();
 });
 
-test('boolean option used with value', (t) => {
+test('boolean option used with value', () => {
   const passedArgs = ['--foo=bar'];
   const passedOptions = { foo: { type: 'boolean' } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
   });
-
-  t.end();
 });
 
-test('invalid short option length', (t) => {
+test('invalid short option length', () => {
   const passedArgs = [];
   const passedOptions = { foo: { short: 'fo', type: 'boolean' } };
-
-  t.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
+  assert.throws(() => { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_INVALID_ARG_VALUE'
   });
-
-  t.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -298,7 +298,7 @@ test('invalid argument passed for options', () => {
   });
 });
 
-test('then type property missing for option then throw', () => {
+test('type property missing for option then throw', () => {
   const knownOptions = { foo: { } };
   assert.throws(() => { parseArgs({ options: knownOptions }); }, {
     code: 'ERR_INVALID_ARG_TYPE'

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const tape = require('tape');
+
+module.exports = {
+  test: (description, body) => {
+    tape(description, (t) => {
+      t.deepStrictEqual = t.deepEqual;
+      global.assert = t;
+      body();
+      t.end();
+    });
+  }
+};


### PR DESCRIPTION
tldr; make it so we can drop `test/index.js` into `test/parallel/test-parse-args.mjs`.

----

Refactors index.js to be able to copy paste directly into the Node.js
codebase. Note: I think it is sufficient that we continue syncing just
the tests for parseArgs() to Node.js (testing the public API. This
gives us 95% coverage today, and it would be easy to push this to
100% with a couple additional tests.

Fixes #105