### PR TITLE
Make positionals opt-in when strict:true

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ added: REPLACEME
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.
     **Default:** `true`.
+  * `allowPositionals`: {boolean} Whether this command accepts positional arguments.
+    **Default:** `false` if `strict` is `true`, otherwise `true`.
 
 * Returns: {Object} An {Object} representing the parsed command line
   arguments:
@@ -133,7 +135,7 @@ This package was implemented using [tape](https://www.npmjs.com/package/tape) as
 ## 💡 `process.mainArgs` Proposal
 
 > Note: This can be moved forward independently of the `util.parseArgs()` proposal/work.
- 
+
 ### Implementation:
 
 ```javascript
@@ -273,7 +275,7 @@ const { values, positionals } = parseArgs({ strict: false, args, options });
   - no, `-bar` is a short option or options, with expansion logic that follows the
     [Utility Syntax Guidelines in POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html). `-bar` expands to `-b`, `-a`, `-r`.
 - Is `---foo` the same as `--foo`?
-  - no 
+  - no
   - the first is a long option named `'-foo'`
   - the second is a long option named `'foo'`
 - Is `-` a positional? ie, `bash some-test.sh | tap -`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ added: REPLACEME
   * `positionals` {string\[]}, containing positional arguments.
 
 Provides a higher level API for command-line argument parsing than interacting
-with `process.argv` directly. Takes a specification for the expected options and returns a structured object corresponding to passed arguments.
+with `process.argv` directly. Takes a specification for the expected arguments and returns a structured object with the parsed options and positionals.
 
 ```mjs
 import { parseArgs } from 'util';

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ added: REPLACEME
   * `positionals` {string\[]}, containing positional arguments.
 
 Provides a higher level API for command-line argument parsing than interacting
-with `process.argv` directly.
+with `process.argv` directly. Takes a specification for the expected options and returns a structured object corresponding to passed arguments.
 
 ```mjs
 import { parseArgs } from 'util';
@@ -155,6 +155,7 @@ process.mainArgs = process.argv.slice(process._exec ? 1 : 2)
     * `multiple` {boolean} (Optional) If true, when appearing one or more times in `args`, results are collected in an `Array`
     * `short` {string} (Optional) A single character alias for an option; When appearing one or more times in `args`; Respects the `multiple` configuration
   * `strict` {Boolean} (Optional) A `Boolean` for whether or not to throw an error when unknown options are encountered, `type:'string'` options are missing an options-argument, or `type:'boolean'` options are passed an options-argument; defaults to `true`
+  * `allowPositionals` {Boolean} (Optional) Whether this command accepts positional arguments. Defaults `false` if `strict` is `true`, otherwise defaults to `true`.
 * Returns: {Object} An object having properties:
   * `values` {Object}, key:value for each option found. Value is a string for string options, or `true` for boolean options, or an array (of strings or booleans) for options configured as `multiple:true`.
   * `positionals` {string[]}, containing [Positionals][]
@@ -205,7 +206,7 @@ const options = {
   },
 };
 const args = ['-f', 'b'];
-const { values, positionals } = parseArgs({ args, options });
+const { values, positionals } = parseArgs({ args, options, allowPositionals: true });
 // values = { foo: true }
 // positionals = ['b']
 ```
@@ -215,7 +216,7 @@ const { parseArgs } = require('@pkgjs/parseargs');
 // unconfigured
 const options = {};
 const args = ['-f', '--foo=a', '--bar', 'b'];
-const { values, positionals } = parseArgs({ strict: false, args, options });
+const { values, positionals } = parseArgs({ strict: false, args, options, allowPositionals: true });
 // values = { f: true, foo: 'a', bar: true }
 // positionals = ['b']
 ```

--- a/errors.js
+++ b/errors.js
@@ -22,8 +22,9 @@ class ERR_PARSE_ARGS_INVALID_OPTION_VALUE extends Error {
 }
 
 class ERR_PARSE_ARGS_UNKNOWN_OPTION extends Error {
-  constructor(option) {
-    super(`Unknown option '${option}'`);
+  constructor(option, allowPositionals) {
+    const suggestDashDash = allowPositionals ? `. To specify a positional argument starting with a '-', place it at the end of the command after '--', as in '-- ${JSON.stringify(option)}` : '';
+    super(`Unknown option '${option}'${suggestDashDash}`);
     this.code = 'ERR_PARSE_ARGS_UNKNOWN_OPTION';
   }
 }

--- a/errors.js
+++ b/errors.js
@@ -28,11 +28,19 @@ class ERR_PARSE_ARGS_UNKNOWN_OPTION extends Error {
   }
 }
 
+class ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL extends Error {
+  constructor(positional) {
+    super(`Unexpected argument '${positional}'. This command does not take positional arguments`);
+    this.code = 'ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL';
+  }
+}
+
 module.exports = {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_PARSE_ARGS_INVALID_OPTION_VALUE,
     ERR_PARSE_ARGS_UNKNOWN_OPTION,
+    ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL,
   }
 };

--- a/index.js
+++ b/index.js
@@ -87,12 +87,12 @@ function getMainArgs() {
  * @param {boolean} strict - show errors, from parseArgs({ strict })
  */
 function checkOptionUsage(longOption, optionValue, options,
-                          shortOrLong, strict) {
+                          shortOrLong, strict, allowPositionals) {
   // Strict and options are used from local context.
   if (!strict) return;
 
   if (!ObjectHasOwn(options, longOption)) {
-    throw new ERR_PARSE_ARGS_UNKNOWN_OPTION(shortOrLong);
+    throw new ERR_PARSE_ARGS_UNKNOWN_OPTION(shortOrLong, allowPositionals);
   }
 
   const short = optionsGetOwn(options, longOption, 'short');
@@ -211,7 +211,8 @@ const parseArgs = (config = { __proto__: null }) => {
         // e.g. '-f', 'bar'
         optionValue = ArrayPrototypeShift(remainingArgs);
       }
-      checkOptionUsage(longOption, optionValue, options, arg, strict);
+      checkOptionUsage(longOption, optionValue, options,
+                       arg, strict, allowPositionals);
       storeOption(longOption, optionValue, options, result.values);
       continue;
     }
@@ -242,7 +243,7 @@ const parseArgs = (config = { __proto__: null }) => {
       const shortOption = StringPrototypeCharAt(arg, 1);
       const longOption = findLongOptionForShort(shortOption, options);
       const optionValue = StringPrototypeSlice(arg, 2);
-      checkOptionUsage(longOption, optionValue, options, `-${shortOption}`, strict);
+      checkOptionUsage(longOption, optionValue, options, `-${shortOption}`, strict, allowPositionals);
       storeOption(longOption, optionValue, options, result.values);
       continue;
     }
@@ -256,7 +257,8 @@ const parseArgs = (config = { __proto__: null }) => {
         // e.g. '--foo', 'bar'
         optionValue = ArrayPrototypeShift(remainingArgs);
       }
-      checkOptionUsage(longOption, optionValue, options, arg, strict);
+      checkOptionUsage(longOption, optionValue, options,
+                       arg, strict, allowPositionals);
       storeOption(longOption, optionValue, options, result.values);
       continue;
     }
@@ -266,7 +268,7 @@ const parseArgs = (config = { __proto__: null }) => {
       const index = StringPrototypeIndexOf(arg, '=');
       const longOption = StringPrototypeSlice(arg, 2, index);
       const optionValue = StringPrototypeSlice(arg, index + 1);
-      checkOptionUsage(longOption, optionValue, options, `--${longOption}`, strict);
+      checkOptionUsage(longOption, optionValue, options, `--${longOption}`, strict, allowPositionals);
       storeOption(longOption, optionValue, options, result.values);
       continue;
     }

--- a/test/dash.js
+++ b/test/dash.js
@@ -15,7 +15,7 @@ test("dash: when args include '-' used as positional then result has '-' in posi
   const args = ['-'];
   const expected = { values: { __proto__: null }, positionals: ['-'] };
 
-  const result = parseArgs({ args });
+  const result = parseArgs({ allowPositionals: true, args });
 
   t.deepEqual(result, expected);
   t.end();

--- a/test/short-option-groups.js
+++ b/test/short-option-groups.js
@@ -20,7 +20,7 @@ test('when pass full-config group of booleans then parsed as booleans', (t) => {
   const options = { r: { type: 'boolean' }, f: { type: 'boolean' } };
   const expected = { values: { __proto__: null, r: true, f: true }, positionals: ['p'] };
 
-  const result = parseArgs({ args, options });
+  const result = parseArgs({ allowPositionals: true, args, options });
 
   t.deepEqual(result, expected);
   t.end();


### PR DESCRIPTION
Fixes https://github.com/pkgjs/parseargs/issues/85.

In the second commit I've updated the message for unknown options to suggest using `--`. I'm not sure if this is worth doing, but I figured I'd implement it for discussion; happy to revert if it seems unhelpful.