### PR TITLE
refactor!: drop handling of electron arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,25 +46,7 @@ const {
 } = require('./errors');
 
 function getMainArgs() {
-  // This function is a placeholder for proposed process.mainArgs.
   // Work out where to slice process.argv for user supplied arguments.
-
-  // Electron is an interesting example, with workarounds implemented in
-  // Commander and Yargs. Hopefully Electron would support process.mainArgs
-  // itself and render this workaround moot.
-  //
-  // In a bundled Electron app, the user CLI args directly
-  // follow executable. (No special processing required for unbundled.)
-  // 1) process.versions.electron is either set by electron, or undefined
-  //    see: https://www.electronjs.org/docs/latest/api/process#processversionselectron-readonly
-  // 2) process.defaultApp is undefined in a bundled Electron app, and set
-  //    in an unbundled Electron app
-  //    see: https://www.electronjs.org/docs/latest/api/process#processdefaultapp-readonly
-  // (Not included in tests as hopefully temporary example.)
-  /* c8 ignore next 3 */
-  if (process.versions?.electron && !process.defaultApp) {
-    return ArrayPrototypeSlice(process.argv, 1);
-  }
 
   // Check node options for scenarios where user CLI args follow executable.
   const execArgv = process.execArgv;


### PR DESCRIPTION
@ljharb raised concerns in https://github.com/nodejs/node/pull/42675 that `process.defaultApp` is an electron-specific property added to `process`, and not a well known property "blessed" by Node.js itself.

I also noticed we have no tests that cover accessing `process.defaultApp`.

---

tldr; I think supporting Electron is likely a good call, and we should add this behavior back, but let's do it as a follow on PR, post landing the MVP -- rather than add any additional complexity to https://github.com/nodejs/node/pull/42675.