### PR TITLE
docs: add example example with code from README/documentation

### DIFF
--- a/examples/simple-hard-coded.js
+++ b/examples/simple-hard-coded.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// This example is used in the documentation.
+
+// 1. const { parseArgs } = require('node:util'); // from node
+// 2. const { parseArgs } = require('@pkgjs/parseargs'); // from package
+const { parseArgs } = require('..'); // in repo
+
+const args = ['-f', '--bar', 'b'];
+const options = {
+  foo: {
+    type: 'boolean',
+    short: 'f'
+  },
+  bar: {
+    type: 'string'
+  }
+};
+const {
+  values,
+  positionals
+} = parseArgs({ args, options });
+console.log(values, positionals);
+
+// Try the following:
+//    node simple-hard-coded.js


### PR DESCRIPTION
A pattern I use in Commander is putting all example programs from the documentation into example files with imports so they can be run straight from a checkout of the repo. I find it useful myself to check behaviour matches documentation, besides letting users try them out easily.

This PR adds an example file matching an upstream documentation example, see what you think...

(I do also add examples that don't appear in the documentation for samples of features or usage that are not covered in depth in the README, which we could do here too.)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
