### PR TITLE
docs: rework simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,16 @@ const options = {
   foo: { type: 'boolean', short: 'f' },
   bar: { type: 'string' }
 };
-try {
-  const { values } = parseArgs({ options });
-  console.log(values);
-} catch (err) {
-  console.log(`${err.code}: ${err.message}`);
-}
+const { values } = parseArgs({ options });
+console.log(values);
 ```
 
 The command-line arguments are found implicitly, and parsed into
-the option values. Usage errors by the end-user throw an error.
+the option values.
 
 ```console
 $ node simple.js -f --bar b
 [Object: null prototype] { foo: true, bar: 'b' }
-$ node simple.js --oops
-ERR_PARSE_ARGS_UNKNOWN_OPTION: Unknown option '--oops'
 ```
 
 `util.parseArgs` is experimental and behavior may change. Join the

--- a/README.md
+++ b/README.md
@@ -50,12 +50,8 @@ const options = {
   foo: { type: 'boolean', short: 'f' },
   bar: { type: 'string' }
 };
-try {
-  const { values } = parseArgs({ options });
-  console.log(values);
-} catch (err) {
-  console.log(`${err.code}: ${err.message}`);
-}
+const { values } = parseArgs({ options });
+console.log(values);
 ```
 
 ```cjs

--- a/README.md
+++ b/README.md
@@ -42,44 +42,44 @@ Provides a higher level API for command-line argument parsing than interacting
 with `process.argv` directly. Takes a specification for the expected arguments
 and returns a structured object with the parsed options and positionals.
 
+For example, assuming the following script for `simple.js`:
+
 ```mjs
 import { parseArgs } from 'node:util';
-const args = ['-f', '--bar', 'b'];
 const options = {
-  foo: {
-    type: 'boolean',
-    short: 'f'
-  },
-  bar: {
-    type: 'string'
-  }
+  foo: { type: 'boolean', short: 'f' },
+  bar: { type: 'string' }
 };
-const {
-  values,
-  positionals
-} = parseArgs({ args, options });
-console.log(values, positionals);
-// Prints: [Object: null prototype] { foo: true, bar: 'b' } []
+try {
+  const { values } = parseArgs({ options });
+  console.log(values);
+} catch (err) {
+  console.log(`${err.code}: ${err.message}`);
+}
 ```
 
 ```cjs
 const { parseArgs } = require('node:util');
-const args = ['-f', '--bar', 'b'];
 const options = {
-  foo: {
-    type: 'boolean',
-    short: 'f'
-  },
-  bar: {
-    type: 'string'
-  }
+  foo: { type: 'boolean', short: 'f' },
+  bar: { type: 'string' }
 };
-const {
-  values,
-  positionals
-} = parseArgs({ args, options });
-console.log(values, positionals);
-// Prints: [Object: null prototype] { foo: true, bar: 'b' } []ss
+try {
+  const { values } = parseArgs({ options });
+  console.log(values);
+} catch (err) {
+  console.log(`${err.code}: ${err.message}`);
+}
+```
+
+The command-line arguments are found implicitly, and parsed into
+the option values. Usage errors by the end-user throw an error.
+
+```console
+$ node simple.js -f --bar b
+[Object: null prototype] { foo: true, bar: 'b' }
+$ node simple.js --oops
+ERR_PARSE_ARGS_UNKNOWN_OPTION: Unknown option '--oops'
 ```
 
 `util.parseArgs` is experimental and behavior may change. Join the

--- a/examples/simple-strict.js
+++ b/examples/simple-strict.js
@@ -6,21 +6,17 @@
 // 2. const { parseArgs } = require('@pkgjs/parseargs'); // from package
 const { parseArgs } = require('..'); // in repo
 
-const args = ['-f', '--bar', 'b'];
 const options = {
-  foo: {
-    type: 'boolean',
-    short: 'f'
-  },
-  bar: {
-    type: 'string'
-  }
+  foo: { type: 'boolean', short: 'f' },
+  bar: { type: 'string' }
 };
-const {
-  values,
-  positionals
-} = parseArgs({ args, options });
-console.log(values, positionals);
+try {
+  const { values } = parseArgs({ options });
+  console.log(values);
+} catch (err) {
+  console.log(`${err.code}: ${err.message}`);
+}
 
 // Try the following:
-//    node simple-hard-coded.js
+//    node simple-strict.js -f --bar b
+//    node simple-strict.js --oops

--- a/examples/simple-strict.js
+++ b/examples/simple-strict.js
@@ -15,4 +15,3 @@ console.log(values);
 
 // Try the following:
 //    node simple-strict.js -f --bar b
-//    node simple-strict.js --oops

--- a/examples/simple-strict.js
+++ b/examples/simple-strict.js
@@ -10,12 +10,8 @@ const options = {
   foo: { type: 'boolean', short: 'f' },
   bar: { type: 'string' }
 };
-try {
-  const { values } = parseArgs({ options });
-  console.log(values);
-} catch (err) {
-  console.log(`${err.code}: ${err.message}`);
-}
+const { values } = parseArgs({ options });
+console.log(values);
 
 // Try the following:
 //    node simple-strict.js -f --bar b

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -14,4 +14,4 @@ const { values } = parseArgs({ options });
 console.log(values);
 
 // Try the following:
-//    node simple-strict.js -f --bar b
+//    node simple.js -f --bar b


### PR DESCRIPTION
## Problem

The example in the (upstream) simple example does not show typical usage, with hard-coded args and no command-line invocation. It includes positionals in the return values which will never be present with the simple strict configuration.

## Solution

A range of minor updates:
- don't supply args, use automatic detection
- refactor options to be more compact (and maybe easier to read)
- don't collect positionals from result
- use console block to show example output
- update local example to match

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
