### PR TITLE
chore: add new test from upstream

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -95,6 +95,14 @@ test('handles short-option groups with "short" alias configured', () => {
   assert.deepStrictEqual(result, expected);
 });
 
+test('handles short-option followed by its value', () => {
+  const args = ['-fFILE'];
+  const options = { foo: { short: 'f', type: 'string' } };
+  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
 test('Everything after a bare `--` is considered a positional argument', () => {
   const args = ['--', 'barepositionals', 'mopositionals'];
   const expected = { values: { __proto__: null }, positionals: ['barepositionals', 'mopositionals'] };


### PR DESCRIPTION
We have 100% coverage in this repo (175 tests), but have only copied up the 72 end-to-end tests in `test/index.js` which does not reach 100%. One case has been added upstream.

https://github.com/nodejs/node/pull/43358/files

(I am interested in a big refactor of the tests to make the coverage clearer, but lower hanging fruit currently!)