### PR TITLE
chore: add script to check coverage likely in upstream tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "coverage": "c8 --check-coverage tape 'test/*.js'",
+    "coverup": "c8 --check-coverage --include index.js tape 'test/index.js'",
     "test": "c8 tape 'test/*.js'",
     "posttest": "eslint .",
     "fix": "npm run posttest -- --fix"


### PR DESCRIPTION
Add run-script to give coverage of `index.js` when run `test/index.js`, similar to coverage in upstream.

We have 100% coverage in this repo (175 tests), but have only copied up the 72 end-to-end tests in `test/index.js`. 

See: #133

```console
$ npm run coverup
> @pkgjs/parseargs@0.9.0 coverup
> c8 --check-coverage --include index.js tape 'test/index.js'

TAP version 13
# when short option used as flag then stored as flag
ok 1 should be deeply equivalent
...
----------|---------|----------|---------|---------|-------------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s       
----------|---------|----------|---------|---------|-------------------------
All files |   94.94 |    95.65 |     100 |   94.94 |                         
 index.js |   94.94 |    95.65 |     100 |   94.94 | 126-127,238-242,249-256 
----------|---------|----------|---------|---------|-------------------------
ERROR: Coverage for lines (94.94%) does not meet global threshold (95%)
ERROR: Coverage for statements (94.94%) does not meet global threshold (95%)
```

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
