### PR TITLE
feat: add `default` option parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ changes:
       times. If `true`, all values will be collected in an array. If
       `false`, values for the option are last-wins. **Default:** `false`.
     * `short` {string} A single character alias for the option.
-    * `defaultValue` {string | boolean | string[] | boolean[]} The default option value when it is not set by args.
+    * `default` {string | boolean | string[] | boolean[]} The default option value when it is not set by args.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ changes:
       times. If `true`, all values will be collected in an array. If
       `false`, values for the option are last-wins. **Default:** `false`.
     * `short` {string} A single character alias for the option.
-    * `defaultValue` {string | boolean} The default option value when it is not set by args.
+    * `defaultValue` {string | boolean | string[] | boolean[]} The default option value when it is not set by args.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ changes:
       times. If `true`, all values will be collected in an array. If
       `false`, values for the option are last-wins. **Default:** `false`.
     * `short` {string} A single character alias for the option.
+    * `defaultValue` {string | boolean} The default option value when it is not set by args.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.
@@ -113,6 +114,7 @@ The returned tokens have properties describing:
     Undefined for boolean options.
   * `inlineValue` {boolean | undefined} Whether option value specified inline,
     like `--foo=bar`.
+  * `isDefaultValue` {boolean | undefined} Whether option value is the default one.
 * positional tokens
   * `value` {string} The value of the positional argument in args (i.e. `args[index]`).
 * option-terminator token

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ The returned tokens have properties describing:
     Undefined for boolean options.
   * `inlineValue` {boolean | undefined} Whether option value specified inline,
     like `--foo=bar`.
-  * `isDefaultValue` {boolean | undefined} Whether option value is the default one.
 * positional tokens
   * `value` {string} The value of the positional argument in args (i.e. `args[index]`).
 * option-terminator token

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ changes:
       times. If `true`, all values will be collected in an array. If
       `false`, values for the option are last-wins. **Default:** `false`.
     * `short` {string} A single character alias for the option.
-    * `default` {string | boolean | string[] | boolean[]} The default option value when it is not set by args.
+    * `default` {string | boolean | string\[] | boolean\[]} The default option
+      value when it is not set by args. It must be of the same type as the
+      the `type` property. When `multiple` is `true`, it must be an array.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.

--- a/examples/is-default-value.js
+++ b/examples/is-default-value.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// This example shows how to understand if a default value is used or not.
+
+// 1. const { parseArgs } = require('node:util'); // from node
+// 2. const { parseArgs } = require('@pkgjs/parseargs'); // from package
+const { parseArgs } = require('..'); // in repo
+
+const options = {
+  file: { short: 'f', type: 'string', defaultValue: 'FOO' },
+};
+
+const { values, tokens } = parseArgs({ options, tokens: true });
+
+const isFileDefault = !tokens.some((token) => token.kind === 'option' &&
+ token.name === 'file'
+);
+
+console.log(values);
+console.log(`Is the file option [${values.file}] the default value? ${isFileDefault}`);
+
+// Try the following:
+//    node is-default-value.js
+//    node is-default-value.js -f FILE
+//    node is-default-value.js --file FILE

--- a/examples/is-default-value.js
+++ b/examples/is-default-value.js
@@ -7,7 +7,7 @@
 const { parseArgs } = require('..'); // in repo
 
 const options = {
-  file: { short: 'f', type: 'string', defaultValue: 'FOO' },
+  file: { short: 'f', type: 'string', default: 'FOO' },
 };
 
 const { values, tokens } = parseArgs({ options, tokens: true });

--- a/index.js
+++ b/index.js
@@ -331,17 +331,19 @@ const parseArgs = (config = kEmptyObject) => {
         validateBoolean(multipleOption, `options.${longOption}.multiple`);
       }
 
-      if (ObjectHasOwn(optionConfig, 'default')) {
-        const defaultValue = objectGetOwn(optionConfig, 'default');
-        if (optionType === 'string' && !multipleOption) {
-          validateString(defaultValue, `options.${longOption}.default`);
-        } else if (optionType === 'string' && multipleOption) {
-          validateStringArray(defaultValue, `options.${longOption}.default`);
-        } else if (optionType === 'boolean' && !multipleOption) {
-          validateBoolean(defaultValue, `options.${longOption}.default`);
-        } else if (optionType === 'boolean' && multipleOption) {
-          validateBooleanArray(defaultValue, `options.${longOption}.default`);
+      const defaultValue = objectGetOwn(optionConfig, 'default');
+      if (defaultValue !== undefined) {
+        let validator;
+        switch (optionType) {
+          case 'string':
+            validator = multipleOption ? validateStringArray : validateString;
+            break;
+
+          case 'boolean':
+            validator = multipleOption ? validateBooleanArray : validateBoolean;
+            break;
         }
+        validator(defaultValue, `options.${longOption}.default`);
       }
     }
   );

--- a/index.js
+++ b/index.js
@@ -328,20 +328,18 @@ const parseArgs = (config = kEmptyObject) => {
         }
       }
 
-      const hasMultipleFlag = ObjectHasOwn(optionConfig, 'multiple');
-      if (hasMultipleFlag) {
-        validateBoolean(optionConfig.multiple, `options.${longOption}.multiple`);
-      }
+      validateBoolean(ObjectHasOwn(optionConfig, 'multiple'), `options.${longOption}.multiple`);
 
       if (ObjectHasOwn(optionConfig, 'defaultValue')) {
         const defaultValue = objectGetOwn(optionConfig, 'defaultValue');
-        if (optionType === 'string' && !hasMultipleFlag) {
+        const multipleOption = objectGetOwn(optionConfig, 'multiple');
+        if (optionType === 'string' && !multipleOption) {
           validateString(defaultValue, `options.${longOption}.defaultValue`);
-        } else if (optionType === 'string' && hasMultipleFlag) {
+        } else if (optionType === 'string' && multipleOption) {
           validateStringArray(defaultValue, `options.${longOption}.defaultValue`);
-        } else if (optionType === 'boolean' && !hasMultipleFlag) {
+        } else if (optionType === 'boolean' && !multipleOption) {
           validateBoolean(defaultValue, `options.${longOption}.defaultValue`);
-        } else if (optionType === 'boolean' && hasMultipleFlag) {
+        } else if (optionType === 'boolean' && multipleOption) {
           validateBooleanArray(defaultValue, `options.${longOption}.defaultValue`);
         }
       }

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const {
 
 const {
   kEmptyObject,
+  isDefaultValueOptionUsed,
 } = require('./internal/util');
 
 const {
@@ -105,7 +106,7 @@ function checkOptionUsage(config, token) {
     throw new ERR_PARSE_ARGS_INVALID_OPTION_VALUE(`Option '${shortAndLong} <value>' argument missing`);
   }
   // (Idiomatic test for undefined||null, expecting undefined.)
-  if (type === 'boolean' && token.value != null && !token.isDefaultValue) {
+  if (type === 'boolean' && token.value != null) {
     throw new ERR_PARSE_ARGS_INVALID_OPTION_VALUE(`Option '${shortAndLong}' does not take an argument`);
   }
 }
@@ -268,18 +269,6 @@ function argsToTokens(args, options) {
   }
 
   return tokens;
-}
-
-/**
- * Check if the given option that includes a default value
- * has been set by the input args.
- *
- * @param {array} options - option configs entry, from parseArgs({ options })
- * @param {object} values - option values returned in `values` by parseArgs
- */
-function isDefaultValueOptionUsed({ 0: longOption, 1: optionConfig }, values) {
-  return optionConfig.defaultValue !== undefined &&
-  !objectGetOwn(values, longOption);
 }
 
 const parseArgs = (config = kEmptyObject) => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const {
   ArrayPrototypeForEach,
   ArrayPrototypeIncludes,
   ArrayPrototypeMap,
-  ArrayPrototypeFilter,
   ArrayPrototypePush,
   ArrayPrototypePushApply,
   ArrayPrototypeShift,
@@ -332,16 +331,16 @@ const parseArgs = (config = kEmptyObject) => {
         validateBoolean(multipleOption, `options.${longOption}.multiple`);
       }
 
-      if (ObjectHasOwn(optionConfig, 'defaultValue')) {
-        const defaultValue = objectGetOwn(optionConfig, 'defaultValue');
+      if (ObjectHasOwn(optionConfig, 'default')) {
+        const defaultValue = objectGetOwn(optionConfig, 'default');
         if (optionType === 'string' && !multipleOption) {
-          validateString(defaultValue, `options.${longOption}.defaultValue`);
+          validateString(defaultValue, `options.${longOption}.default`);
         } else if (optionType === 'string' && multipleOption) {
-          validateStringArray(defaultValue, `options.${longOption}.defaultValue`);
+          validateStringArray(defaultValue, `options.${longOption}.default`);
         } else if (optionType === 'boolean' && !multipleOption) {
-          validateBoolean(defaultValue, `options.${longOption}.defaultValue`);
+          validateBoolean(defaultValue, `options.${longOption}.default`);
         } else if (optionType === 'boolean' && multipleOption) {
-          validateBooleanArray(defaultValue, `options.${longOption}.defaultValue`);
+          validateBooleanArray(defaultValue, `options.${longOption}.default`);
         }
       }
     }
@@ -374,21 +373,18 @@ const parseArgs = (config = kEmptyObject) => {
   });
 
   // Phase 3: fill in default values for missing args
-  const defaultValueOptions = ArrayPrototypeFilter(
-    ObjectEntries(options), ({ 0: longOption,
-                               1: optionConfig }) => {
-      return useDefaultValueOption(longOption, optionConfig, result.values);
-    });
-
-  if (defaultValueOptions.length > 0) {
-    ArrayPrototypeForEach(defaultValueOptions, ({ 0: longOption,
-                                                  1: optionConfig }) => {
+  ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption,
+                                                   1: optionConfig }) => {
+    const mustSetDefault = useDefaultValueOption(longOption,
+                                                 optionConfig,
+                                                 result.values);
+    if (mustSetDefault) {
       storeDefaultOption(longOption,
-                         optionConfig.defaultValue,
+                         objectGetOwn(optionConfig, 'default'),
                          result.values);
-    });
+    }
+  });
 
-  }
 
   return result;
 };

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const {
 } = require('./internal/validators');
 
 const {
-  kEmptyObject
+  kEmptyObject,
 } = require('./internal/util');
 
 const {
@@ -154,10 +154,9 @@ function storeOption(longOption, optionValue, options, values) {
  *         | boolean
  *         | string[]
  *         | boolean[]} optionValue - default value from option config
- * @param {object} options - option configs, from parseArgs({ options })
  * @param {object} values - option values returned in `values` by parseArgs
  */
-function storeDefaultOption(longOption, optionValue, options, values) {
+function storeDefaultOption(longOption, optionValue, values) {
   if (longOption === '__proto__') {
     return; // No. Just no.
   }
@@ -376,8 +375,9 @@ const parseArgs = (config = kEmptyObject) => {
 
   // Phase 3: fill in default values for missing args
   const defaultValueOptions = ArrayPrototypeFilter(
-    ObjectEntries(options), (option) => {
-      return useDefaultValueOption(option, result.values);
+    ObjectEntries(options), ({ 0: longOption,
+                               1: optionConfig }) => {
+      return useDefaultValueOption(longOption, optionConfig, result.values);
     });
 
   if (defaultValueOptions.length > 0) {
@@ -385,7 +385,6 @@ const parseArgs = (config = kEmptyObject) => {
                                                   1: optionConfig }) => {
       storeDefaultOption(longOption,
                          optionConfig.defaultValue,
-                         options,
                          result.values);
     });
 

--- a/index.js
+++ b/index.js
@@ -328,11 +328,13 @@ const parseArgs = (config = kEmptyObject) => {
         }
       }
 
-      validateBoolean(ObjectHasOwn(optionConfig, 'multiple'), `options.${longOption}.multiple`);
+      const multipleOption = objectGetOwn(optionConfig, 'multiple');
+      if (ObjectHasOwn(optionConfig, 'multiple')) {
+        validateBoolean(multipleOption, `options.${longOption}.multiple`);
+      }
 
       if (ObjectHasOwn(optionConfig, 'defaultValue')) {
         const defaultValue = objectGetOwn(optionConfig, 'defaultValue');
-        const multipleOption = objectGetOwn(optionConfig, 'multiple');
         if (optionType === 'string' && !multipleOption) {
           validateString(defaultValue, `options.${longOption}.defaultValue`);
         } else if (optionType === 'string' && multipleOption) {

--- a/internal/validators.js
+++ b/internal/validators.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// This file is a proxy of the original file located at:
+// https://github.com/nodejs/node/blob/main/lib/internal/validators.js
+// Every addition or modification to this file must be evaluated
+// during the PR review.
+
 const {
   ArrayIsArray,
   ArrayPrototypeIncludes,

--- a/internal/validators.js
+++ b/internal/validators.js
@@ -36,6 +36,20 @@ function validateArray(value, name) {
   }
 }
 
+function validateStringArray(value, name) {
+  validateArray(value, name);
+  for (let i = 0; i < value.length; i++) {
+    validateString(value[i], `${name}[${i}]`);
+  }
+}
+
+function validateBooleanArray(value, name) {
+  validateArray(value, name);
+  for (let i = 0; i < value.length; i++) {
+    validateBoolean(value[i], `${name}[${i}]`);
+  }
+}
+
 /**
  * @param {unknown} value
  * @param {string} name
@@ -63,6 +77,8 @@ module.exports = {
   validateArray,
   validateObject,
   validateString,
+  validateStringArray,
   validateUnion,
   validateBoolean,
+  validateBooleanArray,
 };

--- a/test/default-values.js
+++ b/test/default-values.js
@@ -15,6 +15,26 @@ test('defaultValue must be a boolean when option type is boolean', (t) => {
   t.end();
 });
 
+test('defaultValue must be a boolean array when option type is boolean and multiple', (t) => {
+  const args = [];
+  const options = { alpha: { type: 'boolean', multiple: true, defaultValue: 'not an array' } };
+  t.throws(() => {
+    parseArgs({ args, options });
+  }, /alpha\.defaultValue must be Array/
+  );
+  t.end();
+});
+
+test('defaultValue must be a boolean array when option type is string and multiple is true', (t) => {
+  const args = [];
+  const options = { alpha: { type: 'boolean', multiple: true, defaultValue: [true, true, 42] } };
+  t.throws(() => {
+    parseArgs({ args, options });
+  }, /alpha\.defaultValue\[2\] must be Boolean/
+  );
+  t.end();
+});
+
 test('defaultValue must be a string when option type is string', (t) => {
   const args = [];
   const options = { alpha: { type: 'string', defaultValue: true } };
@@ -22,6 +42,49 @@ test('defaultValue must be a string when option type is string', (t) => {
     parseArgs({ args, options });
   }, /alpha\.defaultValue must be String/
   );
+  t.end();
+});
+
+test('defaultValue must be an array when option type is string and multiple is true', (t) => {
+  const args = [];
+  const options = { alpha: { type: 'string', multiple: true, defaultValue: 'not an array' } };
+  t.throws(() => {
+    parseArgs({ args, options });
+  }, /alpha\.defaultValue must be Array/
+  );
+  t.end();
+});
+
+test('defaultValue must be a string array when option type is string and multiple is true', (t) => {
+  const args = [];
+  const options = { alpha: { type: 'string', multiple: true, defaultValue: ['str', 42] } };
+  t.throws(() => {
+    parseArgs({ args, options });
+  }, /alpha\.defaultValue\[1\] must be String/
+  );
+  t.end();
+});
+
+test('defaultValue accepted input when multiple is true', (t) => {
+  const args = ['--inputStringArr', 'c', '--inputStringArr', 'd', '--inputBoolArr', '--inputBoolArr'];
+  const options = {
+    inputStringArr: { type: 'string', multiple: true, defaultValue: ['a', 'b'] },
+    emptyStringArr: { type: 'string', multiple: true, defaultValue: [] },
+    fullStringArr: { type: 'string', multiple: true, defaultValue: ['a', 'b'] },
+    inputBoolArr: { type: 'boolean', multiple: true, defaultValue: [false, true, false] },
+    emptyBoolArr: { type: 'boolean', multiple: true, defaultValue: [] },
+    fullBoolArr: { type: 'boolean', multiple: true, defaultValue: [false, true, false] },
+  };
+  const expected = { values: { __proto__: null,
+                               inputStringArr: ['c', 'd'],
+                               inputBoolArr: [true, true],
+                               emptyStringArr: [],
+                               fullStringArr: ['a', 'b'],
+                               emptyBoolArr: [],
+                               fullBoolArr: [false, true, false] },
+                     positionals: [] };
+  const result = parseArgs({ args, options });
+  t.deepEqual(result, expected);
   t.end();
 });
 
@@ -86,5 +149,18 @@ test('tokens:true should not include the defaultValue options after the args inp
 
   const { tokens } = parseArgs({ args, options, tokens: true, allowPositionals: true });
   t.deepEqual(tokens, expectedTokens);
+  t.end();
+});
+
+test('proto as default value must be ignored', (t) => {
+  const args = [];
+  const options = Object.create(null);
+
+  // eslint-disable-next-line no-proto
+  options.__proto__ = { type: 'string', defaultValue: 'HELLO' };
+
+  const result = parseArgs({ args, options, allowPositionals: true });
+  const expected = { values: { __proto__: null }, positionals: [] };
+  t.deepEqual(result, expected);
   t.end();
 });

--- a/test/default-values.js
+++ b/test/default-values.js
@@ -1,0 +1,97 @@
+'use strict';
+
+/* eslint max-len: 0 */
+
+const test = require('tape');
+const { parseArgs } = require('../index.js');
+
+test('defaultValue must be a boolean when option type is boolean', (t) => {
+  const args = [];
+  const options = { alpha: { type: 'boolean', defaultValue: 'not a boolean' } };
+  t.throws(() => {
+    parseArgs({ args, options });
+  }, /alpha\.defaultValue must be Boolean/
+  );
+  t.end();
+});
+
+test('defaultValue must be a string when option type is string', (t) => {
+  const args = [];
+  const options = { alpha: { type: 'string', defaultValue: true } };
+  t.throws(() => {
+    parseArgs({ args, options });
+  }, /alpha\.defaultValue must be String/
+  );
+  t.end();
+});
+
+test('when defaultValue is set, the option must be added as result', (t) => {
+  const args = [];
+  const options = {
+    a: { type: 'string', defaultValue: 'HELLO' },
+    b: { type: 'boolean', defaultValue: false },
+    c: { type: 'boolean', defaultValue: true }
+  };
+  const expected = { values: { __proto__: null, a: 'HELLO', b: false, c: true }, positionals: [] };
+
+  const result = parseArgs({ args, options });
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('when defaultValue is set, the args value takes precedence', (t) => {
+  const args = ['--a', 'WORLD', '--b', '-c'];
+  const options = {
+    a: { type: 'string', defaultValue: 'HELLO' },
+    b: { type: 'boolean', defaultValue: false },
+    c: { type: 'boolean', defaultValue: true }
+  };
+  const expected = { values: { __proto__: null, a: 'WORLD', b: true, c: true }, positionals: [] };
+
+  const result = parseArgs({ args, options });
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('tokens should include the defaultValue options', (t) => {
+  const args = [];
+  const options = {
+    a: { type: 'string', defaultValue: 'HELLO' },
+    b: { type: 'boolean', defaultValue: false },
+    c: { type: 'boolean', defaultValue: true }
+  };
+
+  const expectedTokens = [
+    { kind: 'option', index: 0, name: 'a', value: 'HELLO', inlineValue: false, isDefaultValue: true },
+    { kind: 'option', index: 1, name: 'b', value: false, inlineValue: false, isDefaultValue: true },
+    { kind: 'option', index: 2, name: 'c', value: true, inlineValue: false, isDefaultValue: true },
+  ];
+
+  const { tokens } = parseArgs({ args, options, tokens: true });
+  t.deepEqual(tokens, expectedTokens);
+  t.end();
+});
+
+test('tokens:true should include the defaultValue options after the args input', (t) => {
+  const args = ['--z', 'zero', 'positional-item'];
+  const options = {
+    z: { type: 'string' },
+    a: { type: 'string', defaultValue: 'HELLO' },
+    b: { type: 'boolean', defaultValue: false },
+    c: { type: 'boolean', defaultValue: true }
+  };
+
+  const expectedTokens = [
+    { kind: 'option', name: 'z', rawName: '--z', index: 0, value: 'zero', inlineValue: false },
+    { kind: 'positional', index: 2, value: 'positional-item' },
+    { kind: 'option', index: 3, name: 'a', value: 'HELLO', inlineValue: false, isDefaultValue: true },
+    { kind: 'option', index: 4, name: 'b', value: false, inlineValue: false, isDefaultValue: true },
+    { kind: 'option', index: 5, name: 'c', value: true, inlineValue: false, isDefaultValue: true },
+  ];
+
+  const { tokens } = parseArgs({ args, options, tokens: true, allowPositionals: true });
+  t.deepEqual(tokens, expectedTokens);
+  t.end();
+});

--- a/test/default-values.js
+++ b/test/default-values.js
@@ -5,75 +5,75 @@
 const test = require('tape');
 const { parseArgs } = require('../index.js');
 
-test('defaultValue must be a boolean when option type is boolean', (t) => {
+test('default must be a boolean when option type is boolean', (t) => {
   const args = [];
-  const options = { alpha: { type: 'boolean', defaultValue: 'not a boolean' } };
+  const options = { alpha: { type: 'boolean', default: 'not a boolean' } };
   t.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.defaultValue must be Boolean/
+  }, /alpha\.default must be Boolean/
   );
   t.end();
 });
 
-test('defaultValue must be a boolean array when option type is boolean and multiple', (t) => {
+test('default must be a boolean array when option type is boolean and multiple', (t) => {
   const args = [];
-  const options = { alpha: { type: 'boolean', multiple: true, defaultValue: 'not an array' } };
+  const options = { alpha: { type: 'boolean', multiple: true, default: 'not an array' } };
   t.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.defaultValue must be Array/
+  }, /alpha\.default must be Array/
   );
   t.end();
 });
 
-test('defaultValue must be a boolean array when option type is string and multiple is true', (t) => {
+test('default must be a boolean array when option type is string and multiple is true', (t) => {
   const args = [];
-  const options = { alpha: { type: 'boolean', multiple: true, defaultValue: [true, true, 42] } };
+  const options = { alpha: { type: 'boolean', multiple: true, default: [true, true, 42] } };
   t.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.defaultValue\[2\] must be Boolean/
+  }, /alpha\.default\[2\] must be Boolean/
   );
   t.end();
 });
 
-test('defaultValue must be a string when option type is string', (t) => {
+test('default must be a string when option type is string', (t) => {
   const args = [];
-  const options = { alpha: { type: 'string', defaultValue: true } };
+  const options = { alpha: { type: 'string', default: true } };
   t.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.defaultValue must be String/
+  }, /alpha\.default must be String/
   );
   t.end();
 });
 
-test('defaultValue must be an array when option type is string and multiple is true', (t) => {
+test('default must be an array when option type is string and multiple is true', (t) => {
   const args = [];
-  const options = { alpha: { type: 'string', multiple: true, defaultValue: 'not an array' } };
+  const options = { alpha: { type: 'string', multiple: true, default: 'not an array' } };
   t.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.defaultValue must be Array/
+  }, /alpha\.default must be Array/
   );
   t.end();
 });
 
-test('defaultValue must be a string array when option type is string and multiple is true', (t) => {
+test('default must be a string array when option type is string and multiple is true', (t) => {
   const args = [];
-  const options = { alpha: { type: 'string', multiple: true, defaultValue: ['str', 42] } };
+  const options = { alpha: { type: 'string', multiple: true, default: ['str', 42] } };
   t.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.defaultValue\[1\] must be String/
+  }, /alpha\.default\[1\] must be String/
   );
   t.end();
 });
 
-test('defaultValue accepted input when multiple is true', (t) => {
+test('default accepted input when multiple is true', (t) => {
   const args = ['--inputStringArr', 'c', '--inputStringArr', 'd', '--inputBoolArr', '--inputBoolArr'];
   const options = {
-    inputStringArr: { type: 'string', multiple: true, defaultValue: ['a', 'b'] },
-    emptyStringArr: { type: 'string', multiple: true, defaultValue: [] },
-    fullStringArr: { type: 'string', multiple: true, defaultValue: ['a', 'b'] },
-    inputBoolArr: { type: 'boolean', multiple: true, defaultValue: [false, true, false] },
-    emptyBoolArr: { type: 'boolean', multiple: true, defaultValue: [] },
-    fullBoolArr: { type: 'boolean', multiple: true, defaultValue: [false, true, false] },
+    inputStringArr: { type: 'string', multiple: true, default: ['a', 'b'] },
+    emptyStringArr: { type: 'string', multiple: true, default: [] },
+    fullStringArr: { type: 'string', multiple: true, default: ['a', 'b'] },
+    inputBoolArr: { type: 'boolean', multiple: true, default: [false, true, false] },
+    emptyBoolArr: { type: 'boolean', multiple: true, default: [] },
+    fullBoolArr: { type: 'boolean', multiple: true, default: [false, true, false] },
   };
   const expected = { values: { __proto__: null,
                                inputStringArr: ['c', 'd'],
@@ -88,12 +88,12 @@ test('defaultValue accepted input when multiple is true', (t) => {
   t.end();
 });
 
-test('when defaultValue is set, the option must be added as result', (t) => {
+test('when default is set, the option must be added as result', (t) => {
   const args = [];
   const options = {
-    a: { type: 'string', defaultValue: 'HELLO' },
-    b: { type: 'boolean', defaultValue: false },
-    c: { type: 'boolean', defaultValue: true }
+    a: { type: 'string', default: 'HELLO' },
+    b: { type: 'boolean', default: false },
+    c: { type: 'boolean', default: true }
   };
   const expected = { values: { __proto__: null, a: 'HELLO', b: false, c: true }, positionals: [] };
 
@@ -103,12 +103,12 @@ test('when defaultValue is set, the option must be added as result', (t) => {
   t.end();
 });
 
-test('when defaultValue is set, the args value takes precedence', (t) => {
+test('when default is set, the args value takes precedence', (t) => {
   const args = ['--a', 'WORLD', '--b', '-c'];
   const options = {
-    a: { type: 'string', defaultValue: 'HELLO' },
-    b: { type: 'boolean', defaultValue: false },
-    c: { type: 'boolean', defaultValue: true }
+    a: { type: 'string', default: 'HELLO' },
+    b: { type: 'boolean', default: false },
+    c: { type: 'boolean', default: true }
   };
   const expected = { values: { __proto__: null, a: 'WORLD', b: true, c: true }, positionals: [] };
 
@@ -118,12 +118,12 @@ test('when defaultValue is set, the args value takes precedence', (t) => {
   t.end();
 });
 
-test('tokens should not include the defaultValue options', (t) => {
+test('tokens should not include the default options', (t) => {
   const args = [];
   const options = {
-    a: { type: 'string', defaultValue: 'HELLO' },
-    b: { type: 'boolean', defaultValue: false },
-    c: { type: 'boolean', defaultValue: true }
+    a: { type: 'string', default: 'HELLO' },
+    b: { type: 'boolean', default: false },
+    c: { type: 'boolean', default: true }
   };
 
   const expectedTokens = [];
@@ -133,13 +133,13 @@ test('tokens should not include the defaultValue options', (t) => {
   t.end();
 });
 
-test('tokens:true should not include the defaultValue options after the args input', (t) => {
+test('tokens:true should not include the default options after the args input', (t) => {
   const args = ['--z', 'zero', 'positional-item'];
   const options = {
     z: { type: 'string' },
-    a: { type: 'string', defaultValue: 'HELLO' },
-    b: { type: 'boolean', defaultValue: false },
-    c: { type: 'boolean', defaultValue: true }
+    a: { type: 'string', default: 'HELLO' },
+    b: { type: 'boolean', default: false },
+    c: { type: 'boolean', default: true }
   };
 
   const expectedTokens = [
@@ -157,7 +157,7 @@ test('proto as default value must be ignored', (t) => {
   const options = Object.create(null);
 
   // eslint-disable-next-line no-proto
-  options.__proto__ = { type: 'string', defaultValue: 'HELLO' };
+  options.__proto__ = { type: 'string', default: 'HELLO' };
 
   const result = parseArgs({ args, options, allowPositionals: true });
   const expected = { values: { __proto__: null }, positionals: [] };
@@ -168,10 +168,10 @@ test('proto as default value must be ignored', (t) => {
 
 test('multiple as false should expect a String and not an array', (t) => {
   const args = [];
-  const options = { alpha: { type: 'string', multiple: false, defaultValue: 42 } };
+  const options = { alpha: { type: 'string', multiple: false, default: 42 } };
   t.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.defaultValue must be String/
+  }, /alpha\.default must be String/
   );
   t.end();
 });

--- a/test/default-values.js
+++ b/test/default-values.js
@@ -1,71 +1,78 @@
+/* global assert */
+/* eslint max-len: 0 */
 'use strict';
 
-/* eslint max-len: 0 */
-
-const test = require('tape');
+const { test } = require('./utils');
 const { parseArgs } = require('../index.js');
 
-test('default must be a boolean when option type is boolean', (t) => {
+test('default must be a boolean when option type is boolean', () => {
   const args = [];
   const options = { alpha: { type: 'boolean', default: 'not a boolean' } };
-  t.throws(() => {
+  assert.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.default must be Boolean/
+  }, /options\.alpha\.default must be Boolean/
   );
-  t.end();
 });
 
-test('default must be a boolean array when option type is boolean and multiple', (t) => {
+test('default must accept undefined value', () => {
+  const args = [];
+  const options = { alpha: { type: 'boolean', default: undefined } };
+  const result = parseArgs({ args, options });
+  const expected = {
+    values: {
+      __proto__: null,
+    },
+    positionals: []
+  };
+  assert.deepStrictEqual(result, expected);
+});
+
+test('default must be a boolean array when option type is boolean and multiple', () => {
   const args = [];
   const options = { alpha: { type: 'boolean', multiple: true, default: 'not an array' } };
-  t.throws(() => {
+  assert.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.default must be Array/
+  }, /options\.alpha\.default must be Array/
   );
-  t.end();
 });
 
-test('default must be a boolean array when option type is string and multiple is true', (t) => {
+test('default must be a boolean array when option type is string and multiple is true', () => {
   const args = [];
   const options = { alpha: { type: 'boolean', multiple: true, default: [true, true, 42] } };
-  t.throws(() => {
+  assert.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.default\[2\] must be Boolean/
+  }, /options\.alpha\.default\[2\] must be Boolean/
   );
-  t.end();
 });
 
-test('default must be a string when option type is string', (t) => {
+test('default must be a string when option type is string', () => {
   const args = [];
   const options = { alpha: { type: 'string', default: true } };
-  t.throws(() => {
+  assert.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.default must be String/
+  }, /options\.alpha\.default must be String/
   );
-  t.end();
 });
 
-test('default must be an array when option type is string and multiple is true', (t) => {
+test('default must be an array when option type is string and multiple is true', () => {
   const args = [];
   const options = { alpha: { type: 'string', multiple: true, default: 'not an array' } };
-  t.throws(() => {
+  assert.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.default must be Array/
+  }, /options\.alpha\.default must be Array/
   );
-  t.end();
 });
 
-test('default must be a string array when option type is string and multiple is true', (t) => {
+test('default must be a string array when option type is string and multiple is true', () => {
   const args = [];
   const options = { alpha: { type: 'string', multiple: true, default: ['str', 42] } };
-  t.throws(() => {
+  assert.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.default\[1\] must be String/
+  }, /options\.alpha\.default\[1\] must be String/
   );
-  t.end();
 });
 
-test('default accepted input when multiple is true', (t) => {
+test('default accepted input when multiple is true', () => {
   const args = ['--inputStringArr', 'c', '--inputStringArr', 'd', '--inputBoolArr', '--inputBoolArr'];
   const options = {
     inputStringArr: { type: 'string', multiple: true, default: ['a', 'b'] },
@@ -84,11 +91,10 @@ test('default accepted input when multiple is true', (t) => {
                                fullBoolArr: [false, true, false] },
                      positionals: [] };
   const result = parseArgs({ args, options });
-  t.deepEqual(result, expected);
-  t.end();
+  assert.deepStrictEqual(result, expected);
 });
 
-test('when default is set, the option must be added as result', (t) => {
+test('when default is set, the option must be added as result', () => {
   const args = [];
   const options = {
     a: { type: 'string', default: 'HELLO' },
@@ -98,12 +104,10 @@ test('when default is set, the option must be added as result', (t) => {
   const expected = { values: { __proto__: null, a: 'HELLO', b: false, c: true }, positionals: [] };
 
   const result = parseArgs({ args, options });
-
-  t.deepEqual(result, expected);
-  t.end();
+  assert.deepStrictEqual(result, expected);
 });
 
-test('when default is set, the args value takes precedence', (t) => {
+test('when default is set, the args value takes precedence', () => {
   const args = ['--a', 'WORLD', '--b', '-c'];
   const options = {
     a: { type: 'string', default: 'HELLO' },
@@ -113,12 +117,10 @@ test('when default is set, the args value takes precedence', (t) => {
   const expected = { values: { __proto__: null, a: 'WORLD', b: true, c: true }, positionals: [] };
 
   const result = parseArgs({ args, options });
-
-  t.deepEqual(result, expected);
-  t.end();
+  assert.deepStrictEqual(result, expected);
 });
 
-test('tokens should not include the default options', (t) => {
+test('tokens should not include the default options', () => {
   const args = [];
   const options = {
     a: { type: 'string', default: 'HELLO' },
@@ -129,11 +131,10 @@ test('tokens should not include the default options', (t) => {
   const expectedTokens = [];
 
   const { tokens } = parseArgs({ args, options, tokens: true });
-  t.deepEqual(tokens, expectedTokens);
-  t.end();
+  assert.deepStrictEqual(tokens, expectedTokens);
 });
 
-test('tokens:true should not include the default options after the args input', (t) => {
+test('tokens:true should not include the default options after the args input', () => {
   const args = ['--z', 'zero', 'positional-item'];
   const options = {
     z: { type: 'string' },
@@ -148,11 +149,10 @@ test('tokens:true should not include the default options after the args input', 
   ];
 
   const { tokens } = parseArgs({ args, options, tokens: true, allowPositionals: true });
-  t.deepEqual(tokens, expectedTokens);
-  t.end();
+  assert.deepStrictEqual(tokens, expectedTokens);
 });
 
-test('proto as default value must be ignored', (t) => {
+test('proto as default value must be ignored', () => {
   const args = [];
   const options = Object.create(null);
 
@@ -161,17 +161,14 @@ test('proto as default value must be ignored', (t) => {
 
   const result = parseArgs({ args, options, allowPositionals: true });
   const expected = { values: { __proto__: null }, positionals: [] };
-  t.deepEqual(result, expected);
-  t.end();
+  assert.deepStrictEqual(result, expected);
 });
 
 
-test('multiple as false should expect a String', (t) => {
+test('multiple as false should expect a String', () => {
   const args = [];
   const options = { alpha: { type: 'string', multiple: false, default: ['array'] } };
-  t.throws(() => {
+  assert.throws(() => {
     parseArgs({ args, options });
-  }, /alpha\.default must be String/
-  );
-  t.end();
+  }, / must be String got array/);
 });

--- a/test/default-values.js
+++ b/test/default-values.js
@@ -166,9 +166,9 @@ test('proto as default value must be ignored', (t) => {
 });
 
 
-test('multiple as false should expect a String and not an array', (t) => {
+test('multiple as false should expect a String', (t) => {
   const args = [];
-  const options = { alpha: { type: 'string', multiple: false, default: 42 } };
+  const options = { alpha: { type: 'string', multiple: false, default: ['array'] } };
   t.throws(() => {
     parseArgs({ args, options });
   }, /alpha\.default must be String/

--- a/test/default-values.js
+++ b/test/default-values.js
@@ -55,7 +55,7 @@ test('when defaultValue is set, the args value takes precedence', (t) => {
   t.end();
 });
 
-test('tokens should include the defaultValue options', (t) => {
+test('tokens should not include the defaultValue options', (t) => {
   const args = [];
   const options = {
     a: { type: 'string', defaultValue: 'HELLO' },
@@ -63,18 +63,14 @@ test('tokens should include the defaultValue options', (t) => {
     c: { type: 'boolean', defaultValue: true }
   };
 
-  const expectedTokens = [
-    { kind: 'option', index: 0, name: 'a', value: 'HELLO', inlineValue: false, isDefaultValue: true },
-    { kind: 'option', index: 1, name: 'b', value: false, inlineValue: false, isDefaultValue: true },
-    { kind: 'option', index: 2, name: 'c', value: true, inlineValue: false, isDefaultValue: true },
-  ];
+  const expectedTokens = [];
 
   const { tokens } = parseArgs({ args, options, tokens: true });
   t.deepEqual(tokens, expectedTokens);
   t.end();
 });
 
-test('tokens:true should include the defaultValue options after the args input', (t) => {
+test('tokens:true should not include the defaultValue options after the args input', (t) => {
   const args = ['--z', 'zero', 'positional-item'];
   const options = {
     z: { type: 'string' },
@@ -86,9 +82,6 @@ test('tokens:true should include the defaultValue options after the args input',
   const expectedTokens = [
     { kind: 'option', name: 'z', rawName: '--z', index: 0, value: 'zero', inlineValue: false },
     { kind: 'positional', index: 2, value: 'positional-item' },
-    { kind: 'option', index: 3, name: 'a', value: 'HELLO', inlineValue: false, isDefaultValue: true },
-    { kind: 'option', index: 4, name: 'b', value: false, inlineValue: false, isDefaultValue: true },
-    { kind: 'option', index: 5, name: 'c', value: true, inlineValue: false, isDefaultValue: true },
   ];
 
   const { tokens } = parseArgs({ args, options, tokens: true, allowPositionals: true });

--- a/test/default-values.js
+++ b/test/default-values.js
@@ -164,3 +164,14 @@ test('proto as default value must be ignored', (t) => {
   t.deepEqual(result, expected);
   t.end();
 });
+
+
+test('multiple as false should not expect an array', (t) => {
+  const args = [];
+  const options = { alpha: { type: 'string', multiple: false, defaultValue: 42 } };
+  t.throws(() => {
+    parseArgs({ args, options });
+  }, /alpha\.defaultValue must be String/
+  );
+  t.end();
+});

--- a/test/default-values.js
+++ b/test/default-values.js
@@ -166,7 +166,7 @@ test('proto as default value must be ignored', (t) => {
 });
 
 
-test('multiple as false should not expect an array', (t) => {
+test('multiple as false should expect a String and not an array', (t) => {
   const args = [];
   const options = { alpha: { type: 'string', multiple: false, defaultValue: 42 } };
   t.throws(() => {

--- a/utils.js
+++ b/utils.js
@@ -179,7 +179,7 @@ function findLongOptionForShort(shortOption, options) {
  * @param {object} values - option values returned in `values` by parseArgs
  */
 function useDefaultValueOption(longOption, optionConfig, values) {
-  return objectGetOwn(optionConfig, 'defaultValue') !== undefined &&
+  return objectGetOwn(optionConfig, 'default') !== undefined &&
   values[longOption] === undefined;
 }
 

--- a/utils.js
+++ b/utils.js
@@ -174,12 +174,12 @@ function findLongOptionForShort(shortOption, options) {
  * Check if the given option includes a default value
  * and that option has not been set by the input args.
  *
- * @param {array} options - option configs entry, from parseArgs({ options })
+ * @param {string} longOption - long option name e.g. 'foo'
+ * @param {object} optionConfig - the option configuration properties
  * @param {object} values - option values returned in `values` by parseArgs
  */
-function useDefaultValueOption({ 0: longOption,
-                                 1: optionConfig }, values) {
-  return optionConfig.defaultValue !== undefined &&
+function useDefaultValueOption(longOption, optionConfig, values) {
+  return objectGetOwn(optionConfig, 'defaultValue') !== undefined &&
   values[longOption] === undefined;
 }
 

--- a/utils.js
+++ b/utils.js
@@ -170,6 +170,19 @@ function findLongOptionForShort(shortOption, options) {
   return longOptionEntry?.[0] ?? shortOption;
 }
 
+/**
+ * Check if the given option includes a default value
+ * and that option has not been set by the input args.
+ *
+ * @param {array} options - option configs entry, from parseArgs({ options })
+ * @param {object} values - option values returned in `values` by parseArgs
+ */
+function useDefaultValueOption({ 0: longOption,
+                                 1: optionConfig }, values) {
+  return optionConfig.defaultValue !== undefined &&
+  values[longOption] === undefined;
+}
+
 module.exports = {
   findLongOptionForShort,
   isLoneLongOption,
@@ -179,6 +192,7 @@ module.exports = {
   isOptionLikeValue,
   isShortOptionAndValue,
   isShortOptionGroup,
+  useDefaultValueOption,
   objectGetOwn,
   optionsGetOwn,
 };

--- a/utils.js
+++ b/utils.js
@@ -180,7 +180,7 @@ function findLongOptionForShort(shortOption, options) {
  */
 function useDefaultValueOption(longOption, optionConfig, values) {
   return objectGetOwn(optionConfig, 'default') !== undefined &&
-  values[longOption] === undefined;
+    values[longOption] === undefined;
 }
 
 module.exports = {


### PR DESCRIPTION
The first implementation of https://github.com/pkgjs/parseargs/issues/82

This PR adds a new `default` parameter.

```js
  const args = [];
  const options = {
    a: { type: 'string', default: 'HELLO' }
  };
  const result = parseArgs({ args, options }); // { values: { a: 'HELLO' } }
```
It lets the user specify an option's default value when it is not set by the `args` input.
When it is set, the `option` token is added automatically.

This pr does not include any process.env logic, but the user may set `default: process.env.WHATEVER`