### PR TITLE
docs: add version matchups for default

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,10 +234,11 @@ It is exceedingly difficult to provide an API which would both be friendly to th
 
 ## Version Matchups
 
-| Node.js | @pkgjs/parseArgs |
-| -- | -- |
+| Node.js | @pkgjs/parseArgs | Changes |
+| -- | -- | -- |
 | [v18.3.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [v0.9.1](https://github.com/pkgjs/parseargs/tree/v0.9.1#utilparseargsconfig) |
-| [v16.17.0](https://nodejs.org/dist/latest-v16.x/docs/api/util.html#utilparseargsconfig), [v18.7.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.10.0](https://github.com/pkgjs/parseargs/tree/v0.10.0#utilparseargsconfig) |
+| [v16.17.0](https://nodejs.org/dist/latest-v16.x/docs/api/util.html#utilparseargsconfig), [v18.7.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.10.0](https://github.com/pkgjs/parseargs/tree/v0.10.0#utilparseargsconfig) | tokens |
+| [v18.11.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.11.0](https://github.com/pkgjs/parseargs/tree/v0.11.0#utilparseargsconfig) | default |
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ It is exceedingly difficult to provide an API which would both be friendly to th
 
 | Node.js | @pkgjs/parseArgs | Changes |
 | -- | -- | -- |
+| [v18.11.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.11.0](https://github.com/pkgjs/parseargs/tree/v0.11.0#utilparseargsconfig) | Add support for default values in input `config`. |
+| [v16.17.0](https://nodejs.org/dist/latest-v16.x/docs/api/util.html#utilparseargsconfig), [v18.7.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.10.0](https://github.com/pkgjs/parseargs/tree/v0.10.0#utilparseargsconfig) | Add support for returning detailed parse information using `tokens` in input config and returned properties. |
 | [v18.3.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [v0.9.1](https://github.com/pkgjs/parseargs/tree/v0.9.1#utilparseargsconfig) |
-| [v16.17.0](https://nodejs.org/dist/latest-v16.x/docs/api/util.html#utilparseargsconfig), [v18.7.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.10.0](https://github.com/pkgjs/parseargs/tree/v0.10.0#utilparseargsconfig) | add support for returning detailed parse information using `tokens` in input config and returned properties. |
-| [v18.11.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.11.0](https://github.com/pkgjs/parseargs/tree/v0.11.0#utilparseargsconfig) | default |
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ It is exceedingly difficult to provide an API which would both be friendly to th
 | Node.js | @pkgjs/parseArgs | Changes |
 | -- | -- | -- |
 | [v18.3.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [v0.9.1](https://github.com/pkgjs/parseargs/tree/v0.9.1#utilparseargsconfig) |
-| [v16.17.0](https://nodejs.org/dist/latest-v16.x/docs/api/util.html#utilparseargsconfig), [v18.7.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.10.0](https://github.com/pkgjs/parseargs/tree/v0.10.0#utilparseargsconfig) | tokens |
+| [v16.17.0](https://nodejs.org/dist/latest-v16.x/docs/api/util.html#utilparseargsconfig), [v18.7.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.10.0](https://github.com/pkgjs/parseargs/tree/v0.10.0#utilparseargsconfig) | add support for returning detailed parse information using `tokens` in input config and returned properties. |
 | [v18.11.0](https://nodejs.org/docs/latest-v18.x/api/util.html#utilparseargsconfig) | [0.11.0](https://github.com/pkgjs/parseargs/tree/v0.11.0#utilparseargsconfig) | default |
 
 ----


### PR DESCRIPTION
Add versions which include support for `default` in input configuration.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
