### PR TITLE
docs: add example of implementing optional-value

### DIFF
--- a/examples/optional-value.mjs
+++ b/examples/optional-value.mjs
@@ -5,24 +5,30 @@ import { parseArgs } from 'node:util';
 import process from 'node:process';
 
 const options = {
-  'host': { type: 'string', preset: 'localhost', short: 'h', default: 'default.com' },
-  'debug': { type: 'boolean', short:'d' },
+  'host': {
+    type: 'string', short: 'h', default: 'default.com',
+    preset: 'localhost'
+  },
+  'debug': { type: 'boolean', short: 'd' },
 };
 
-let args = process.argv.slice(2);
+const args = process.argv.slice(2);
 
 do {
-  const { tokens } = parseArgs({ args, options, strict:false, tokens: true });
+  const { tokens } = parseArgs({ args, options, strict: false, tokens: true });
   // Insert preset if:
   // - missing value, like: --host
-  // - value came from following argument we want to process as option, like: --host --debug
+  // - value came from following option argument, like: --host --debug
   // An empty string is a valid value for a string-type option.
   const needsPreset = tokens.find((token) =>
-    token.kind === 'option'
-    && options[token.name]
-    && options[token.name].type === 'string'
-    && options[token.name].preset !== undefined
-    && (token.value === undefined || (token.value.startsWith('-') && !token.inlineValue)));
+    token.kind === 'option' &&
+    options[token.name] &&
+    options[token.name].type === 'string' &&
+    options[token.name].preset !== undefined &&
+    (
+      token.value === undefined ||
+      (token.value.startsWith('-') && !token.inlineValue)
+    ));
 
   if (!needsPreset) break;
 
@@ -33,7 +39,7 @@ do {
 } while (true);
 
 
-const { values } = parseArgs({args, options, allowPositionals: true });
+const { values } = parseArgs({ args, options });
 console.log(values);
 
 // Try the following:

--- a/examples/optional-value.mjs
+++ b/examples/optional-value.mjs
@@ -1,0 +1,49 @@
+// This is an example of adding support for an option with an optional value,
+// which can be used like a boolean-type or a string-type.
+
+import { parseArgs } from 'node:util';
+import process from 'node:process';
+
+const options = {
+  'host': { type: 'string', preset: 'localhost', short: 'h', default: 'default.com' },
+  'debug': { type: 'boolean', short:'d' },
+};
+
+let args = process.argv.slice(2);
+
+do {
+  const { tokens } = parseArgs({ args, options, strict:false, tokens: true });
+  // Insert preset if:
+  // - missing value, like: --host
+  // - value came from following argument we want to process as option, like: --host --debug
+  // An empty string is a valid value for a string-type option.
+  const needsPreset = tokens.find((token) =>
+    token.kind === 'option'
+    && options[token.name]
+    && options[token.name].type === 'string'
+    && options[token.name].preset !== undefined
+    && (token.value === undefined || (token.value.startsWith('-') && !token.inlineValue)));
+
+  if (!needsPreset) break;
+
+  // Add preset value as an inline value to the original argument.
+  const joiner = args[needsPreset.index].startsWith('--') ? '=' : '';
+  args[needsPreset.index] = `${args[needsPreset.index]}${joiner}${options[needsPreset.name].preset}`;
+
+} while (true);
+
+
+const { values } = parseArgs({args, options, allowPositionals: true });
+console.log(values);
+
+// Try the following:
+//   node optional-value.mjs
+//   node optional-value.mjs -h
+//   node optional-value.mjs --host
+//   node optional-value.mjs -hHOSTNAME
+//   node optional-value.mjs --host=HOSTNAME
+//   node optional-value.mjs --host=
+//   node optional-value.mjs -h -d
+//   node optional-value.mjs -dh
+//   node optional-value.mjs --host --debug
+//   node optional-value.mjs --host -- POSITIONAL

--- a/examples/optional-value.mjs
+++ b/examples/optional-value.mjs
@@ -6,7 +6,9 @@ import process from 'node:process';
 
 const options = {
   'host': {
-    type: 'string', short: 'h', default: 'default.com',
+    type: 'string',
+    short: 'h',
+    default: 'default.com',
     preset: 'localhost'
   },
   'debug': { type: 'boolean', short: 'd' },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Provide an example of implementing optional option values on top of `parseArgs`.

People ask about adding this as a feature, which we do not think is appropriate in `parseArgs` due to making the parsing ambiguous. 

See:
- https://github.com/nodejs/node/issues/53427
- https://github.com/nodejs/node/pull/53434
- https://github.com/nodejs/node/issues/54396

