### PR TITLE
fix(runtime): support runtimes without `global`

### DIFF
--- a/internal/primordials.js
+++ b/internal/primordials.js
@@ -21,6 +21,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
+
+A modification is made to always reference `globalThis` instead of referencing
+both `global` and `globalThis`. See #157.
 */
 
 'use strict';
@@ -189,7 +192,7 @@ function copyPrototype(src, dest, prefix) {
   'Reflect',
 ].forEach((name) => {
   // eslint-disable-next-line no-restricted-globals
-  copyPropsRenamed(global[name], primordials, name);
+  copyPropsRenamed(globalThis[name], primordials, name);
 });
 
 // Create copies of intrinsic objects
@@ -230,7 +233,7 @@ function copyPrototype(src, dest, prefix) {
   'WeakSet',
 ].forEach((name) => {
   // eslint-disable-next-line no-restricted-globals
-  const original = global[name];
+  const original = globalThis[name];
   primordials[name] = original;
   copyPropsRenamed(original, primordials, name);
   copyPrototype(original.prototype, primordials, `${name}Prototype`);
@@ -243,7 +246,7 @@ function copyPrototype(src, dest, prefix) {
   'Promise',
 ].forEach((name) => {
   // eslint-disable-next-line no-restricted-globals
-  const original = global[name];
+  const original = globalThis[name];
   primordials[name] = original;
   copyPropsRenamedBound(original, primordials, name);
   copyPrototype(original.prototype, primordials, `${name}Prototype`);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

Fixes #157. This makes this library / polyfill usable on [gjs](https://gitlab.gnome.org/GNOME/gjs/) as well as any other standards compliant runtime that doesn't refer to the global object as `global`.

I also added a short comment in the copied `internal/primordials.js` to note that this modification has been made so that the header comment remains accurate.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
